### PR TITLE
SeatruckCraftTreeSupport 

### DIFF
--- a/SMLHelper/Handlers/CraftTreeHandler.cs
+++ b/SMLHelper/Handlers/CraftTreeHandler.cs
@@ -1,11 +1,11 @@
 ﻿namespace SMLHelper.V2.Handlers
 {
+    using System;
     using Crafting;
     using Interfaces;
     using Patchers;
-    using Utility;
-    using System;
     using UnityEngine;
+    using Utility;
 
     /// <summary>
     /// A handler class for creating and editing of crafting trees.
@@ -221,7 +221,7 @@
         /// </summary>
         /// <param name="craftTree">The target craft tree to edit.</param>
         /// <param name="craftingItem">The item to craft.</param>
-        
+
         void ICraftTreeHandler.AddCraftingNode(CraftTree.Type craftTree, TechType craftingItem)
         {
             ValidateStandardCraftTree(craftTree);
@@ -250,7 +250,7 @@
         /// <param name="name">The ID of the tab node. Must be unique!</param>
         /// <param name="displayName">The display name of the tab, which will show up when you hover your mouse on the tab.</param>
         /// <param name="sprite">The sprite of the tab.</param>
-        
+
         void ICraftTreeHandler.AddTabNode(CraftTree.Type craftTree, string name, string displayName, UnityEngine.Sprite sprite)
         {
             ValidateStandardCraftTree(craftTree);
@@ -293,7 +293,7 @@
         /// </param>        
         void ICraftTreeHandler.AddTabNode(CraftTree.Type craftTree, string name, string displayName, UnityEngine.Sprite sprite, params string[] stepsToTab)
         {
-            ValidateStandardCraftTree(craftTree);            
+            ValidateStandardCraftTree(craftTree);
             string modName = ReflectionHelper.CallingAssemblyNameByStackTrace();
 
             CraftTreePatcher.TabNodes.Add(new TabNode(stepsToTab, craftTree, new Atlas.Sprite(sprite), modName, name, displayName));
@@ -310,7 +310,7 @@
         /// <para>This means matching the id of the crafted item or the id of the tab name.</para>
         /// <para>Do not include "root" in this path.</para>
         /// </param>
-        
+
         void ICraftTreeHandler.RemoveNode(CraftTree.Type craftTree, params string[] stepsToNode)
         {
             ValidateStandardCraftTree(craftTree);
@@ -331,14 +331,17 @@
                 case CraftTree.Type.Centrifuge:
                 case CraftTree.Type.CyclopsFabricator:
                 case CraftTree.Type.Rocket:
+#if BELOWZERO
+                case CraftTree.Type.SeaTruckFabricator:
+#endif
                     break; // Okay
-                case CraftTree.Type.Unused1:                    
-                case CraftTree.Type.Unused2:                    
+                case CraftTree.Type.Unused1:
+                case CraftTree.Type.Unused2:
                 case CraftTree.Type.None:
                 default:
                     throw new ArgumentException($"{nameof(craftTree)} value of '{craftTree}' does not correspond to a standard crafting tree.{Environment.NewLine}" +
                                             $"This method is intended for use only with standard crafting trees, not custom ones or unused ones.");
-            }   
+            }
         }
     }
 }

--- a/SMLHelper/Patchers/CraftTreePatcher.cs
+++ b/SMLHelper/Patchers/CraftTreePatcher.cs
@@ -1,11 +1,9 @@
 ﻿namespace SMLHelper.V2.Patchers
 {
-    using Harmony;
     using System.Collections.Generic;
     using System.Reflection;
-    using Utility;
     using Crafting;
-    using System;
+    using Harmony;
 
     internal class CraftTreePatcher
     {
@@ -45,7 +43,10 @@
 
             harmony.Patch(AccessTools.Method(typeof(CraftTree), nameof(CraftTree.CyclopsFabricatorScheme)),
                 postfix: new HarmonyMethod(AccessTools.Method(typeof(CraftTreePatcher), nameof(CraftTreePatcher.CyclopsFabricatorSchemePostfix))));
-
+#if BELOWZERO
+            harmony.Patch(AccessTools.Method(typeof(CraftTree), nameof(CraftTree.SeaTruckFabricatorScheme)),
+                postfix: new HarmonyMethod(AccessTools.Method(typeof(CraftTreePatcher), nameof(CraftTreePatcher.SeaTruckFabricatorSchemePostfix))));
+#endif
             Logger.Log($"CraftTreePatcher is done.", LogLevel.Debug);
         }
 
@@ -105,7 +106,14 @@
             PatchCraftTree(ref __result, CraftTree.Type.CyclopsFabricator);
         }
 
-        #endregion
+#if BELOWZERO
+        private static void SeaTruckFabricatorSchemePostfix(ref CraftNode __result)
+        {
+            PatchCraftTree(ref __result, CraftTree.Type.SeaTruckFabricator);
+        }
+#endif
+
+#endregion
 
         #region Handling Nodes
 
@@ -121,7 +129,8 @@
             foreach (TabNode tab in customTabs)
             {
                 // Wrong crafter, skip.
-                if (tab.Scheme != scheme) continue;
+                if (tab.Scheme != scheme)
+                    continue;
 
                 TreeNode currentNode = default;
                 currentNode = nodes;
@@ -155,7 +164,8 @@
             foreach (CraftingNode customNode in customNodes)
             {
                 // Wrong crafter, just skip the node.
-                if (customNode.Scheme != scheme) continue;
+                if (customNode.Scheme != scheme)
+                    continue;
 
                 // Have to do this to make sure C# shuts up.
                 TreeNode node = default;
@@ -168,8 +178,10 @@
                     string currentPath = customNode.Path[i];
                     TreeNode currentNode = node[currentPath];
 
-                    if (currentNode != null) node = currentNode;
-                    else break;
+                    if (currentNode != null)
+                        node = currentNode;
+                    else
+                        break;
                 }
 
                 // Add the node.
@@ -188,7 +200,8 @@
             foreach (Node nodeToRemove in nodesToRemove)
             {
                 // Not for this fabricator. Skip.
-                if (nodeToRemove.Scheme != scheme) continue;
+                if (nodeToRemove.Scheme != scheme)
+                    continue;
 
                 // Get the names of each node in the path to traverse tree until we reach the node we want.
                 TreeNode currentNode = default;


### PR DESCRIPTION
- Adds postpatch to the `SeaTruckFabricatorScheme` method
- Recognizes `CraftTree.Type.SeaTruckFabricator` as a vanilla fabricator scheme
