### PR TITLE
Added SMLProtobufSerializer

### DIFF
--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -92,7 +92,7 @@
             WorldEntityDatabasePatcher.Patch(harmony);
             IngameMenuPatcher.Patch(harmony);
             ProtoBufSerializerPatcher.Patch(harmony);
-            TooltipPatcher.Patch(harmony);
+            //TooltipPatcher.Patch(harmony);
         }
     }
 }

--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -86,6 +86,7 @@
             LootDistributionPatcher.Patch(harmony);
             WorldEntityDatabasePatcher.Patch(harmony);
             IngameMenuPatcher.Patch(harmony);
+            ProtoBufSerializerPatcher.Patch(harmony);
             //TooltipPatcher.Patch(harmony); // Disabled
         }
     }

--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -92,7 +92,7 @@
             WorldEntityDatabasePatcher.Patch(harmony);
             IngameMenuPatcher.Patch(harmony);
             ProtoBufSerializerPatcher.Patch(harmony);
-            //TooltipPatcher.Patch(harmony);
+            TooltipPatcher.Patch(harmony);
         }
     }
 }

--- a/SMLHelper/Patchers/ProtoBufSerializerPatcher.cs
+++ b/SMLHelper/Patchers/ProtoBufSerializerPatcher.cs
@@ -12,8 +12,8 @@
         
         public static void Patch(HarmonyInstance harmony)
         {
-            harmony.Patch(typeof(ProtobufSerializer).GetMethod("Serialize", BindingFlags.NonPublic | BindingFlags.Instance), new HarmonyMethod(typeof(ProtoBufSerializerPatcher), nameof(ProtoBufSerializerPatcher.Prefix_Serialize)));
-            harmony.Patch(typeof(ProtobufSerializer).GetMethod("Deserialize", BindingFlags.NonPublic | BindingFlags.Instance), new HarmonyMethod(typeof(ProtoBufSerializerPatcher), nameof(ProtoBufSerializerPatcher.Prefix_Deserialize)));
+            harmony.Patch(typeof(ProtobufSerializer).GetMethod(nameof(ProtobufSerializer.Serialize), BindingFlags.NonPublic | BindingFlags.Instance), new HarmonyMethod(typeof(ProtoBufSerializerPatcher), nameof(ProtoBufSerializerPatcher.Prefix_Serialize)));
+            harmony.Patch(typeof(ProtobufSerializer).GetMethod(nameof(ProtobufSerializer.Deserialize), BindingFlags.NonPublic | BindingFlags.Instance), new HarmonyMethod(typeof(ProtoBufSerializerPatcher), nameof(ProtoBufSerializerPatcher.Prefix_Deserialize)));
         }
 
         private static bool Prefix_Serialize(Stream stream, object source, Type type)

--- a/SMLHelper/Patchers/ProtoBufSerializerPatcher.cs
+++ b/SMLHelper/Patchers/ProtoBufSerializerPatcher.cs
@@ -1,0 +1,39 @@
+﻿namespace SMLHelper.V2.Patchers
+{
+    using Abstract;
+    using Harmony;
+    using System;
+    using System.IO;
+    using System.Reflection;
+    using Utility;
+
+    internal static class ProtoBufSerializerPatcher
+    {
+        
+        public static void Patch(HarmonyInstance harmony)
+        {
+            harmony.Patch(typeof(ProtobufSerializer).GetMethod("Serialize", BindingFlags.NonPublic | BindingFlags.Instance), new HarmonyMethod(typeof(ProtoBufSerializerPatcher), nameof(ProtoBufSerializerPatcher.Prefix_Serialize)));
+            harmony.Patch(typeof(ProtobufSerializer).GetMethod("Deserialize", BindingFlags.NonPublic | BindingFlags.Instance), new HarmonyMethod(typeof(ProtoBufSerializerPatcher), nameof(ProtoBufSerializerPatcher.Prefix_Deserialize)));
+        }
+
+        private static bool Prefix_Serialize(Stream stream, object source, Type type)
+        {
+            if (SMLProtobufSerializer.CanSerialize(type))
+            {
+                SMLProtobufSerializer.Serialize(stream, source);
+                return false;
+            }
+            return true;
+        }
+
+        private static bool Prefix_Deserialize(Stream stream, object target, Type type)
+        {
+            if (SMLProtobufSerializer.CanSerialize(type))
+            {
+                SMLProtobufSerializer.Deserialize(stream, target, type);
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -218,6 +218,7 @@
     <Compile Include="Patchers\PDAEncyclopediaPatcher.cs" />
     <Compile Include="Patchers\PDAPatcher.cs" />
     <Compile Include="Patchers\PrefabDatabasePatcher.cs" />
+    <Compile Include="Patchers\ProtoBufSerializerPatcher.cs" />
     <Compile Include="Patchers\SpritePatcher.cs" />
     <Compile Include="Patchers\TechTypePatcher.cs" />
     <Compile Include="Patchers\WorldEntityDatabasePatcher.cs" />
@@ -234,6 +235,7 @@
     <Compile Include="Utility\ReflectionHelper.cs" />
     <Compile Include="Utility\SaveUtils.cs" />
     <Compile Include="Utility\SelfCheckingDictionary.cs" />
+    <Compile Include="Utility\SMLProtobufSerializer.cs" />
     <Compile Include="Utility\StorageHelperExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SMLHelper/Utility/SMLProtobufSerializer.cs
+++ b/SMLHelper/Utility/SMLProtobufSerializer.cs
@@ -18,7 +18,12 @@ namespace SMLHelper.V2.Utility
         private static readonly Dictionary<Type, int> knownTypes = ProtobufSerializerPrecompiled.knownTypes;
         private static readonly RuntimeTypeModel model = TypeModel.Create();
 
-        internal static void Serialize(Stream stream, object source)
+        /// <summary>
+        /// Save an object to a stream
+        /// </summary>
+        /// <param name="stream">Stream for the object to be saved to</param>
+        /// <param name="source">Object to be saved</param>
+        public static void Serialize(Stream stream, object source)
         {
             model.SerializeWithLengthPrefix(stream, source, source.GetType(), PrefixStyle.Base128, 0);
         }
@@ -60,7 +65,13 @@ namespace SMLHelper.V2.Utility
             }
         }
 
-        internal static void Deserialize(Stream stream, object target, Type type)
+        /// <summary>
+        /// Load an Object from a Stream
+        /// </summary>
+        /// <param name="stream">Stream to load the object from</param>
+        /// <param name="target">Object output</param>
+        /// <param name="type">Type of the object to load</param>
+        public static void Deserialize(Stream stream, object target, Type type)
         {
             model.DeserializeWithLengthPrefix(stream, target, type, PrefixStyle.Base128, 0);
         }

--- a/SMLHelper/Utility/SMLProtobufSerializer.cs
+++ b/SMLHelper/Utility/SMLProtobufSerializer.cs
@@ -1,0 +1,68 @@
+﻿
+namespace SMLHelper.V2.Utility
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using ProtoBuf;
+    using ProtoBuf.Meta;
+
+    /// <summary>
+    /// Allows saving mod components directly into game files
+    /// </summary>
+    public static class SMLProtobufSerializer
+    {
+        private static readonly Dictionary<Type, int> knownTypes = ProtobufSerializerPrecompiled.knownTypes;
+        private static readonly RuntimeTypeModel model = TypeModel.Create();
+
+        internal static void Serialize(Stream stream, object source)
+        {
+            model.SerializeWithLengthPrefix(stream, source, source.GetType(), PrefixStyle.Base128, 0);
+        }
+
+        /// <summary>
+        /// Checks if a type can be serialized
+        /// </summary>
+        /// <param name="type">Type to check for serializability</param>
+        /// <returns>true if type is registered</returns>
+        public static bool CanSerialize(Type type)
+        {
+            return model.CanSerialize(type);
+        }
+
+        /// <summary>
+        /// Registers Type to be serialized with SMLProtobufSerializer
+        /// </summary>
+        /// <param name="type">Type to be serialized</param>
+        public static void RegisterType(Type type)
+        {
+            model.Add(type, true);
+        }
+
+        /// <summary>
+        /// Registers all types from an assembly to be serialized with SMLProtobufSerializer
+        /// </summary>
+        /// <param name="assembly">Assembly to register types from</param>
+        public static void RegisterTypes(Assembly assembly)
+        {
+            foreach (Type type in assembly.GetTypes())
+            {
+                bool hasUweProtobuf = (type.GetCustomAttributes(typeof(ProtoContractAttribute), false).Length > 0);
+
+                if (hasUweProtobuf)
+                {
+                    model.Add(type, true);
+                    knownTypes[type] = int.MaxValue; // UWE precompiled is going to pass everything that we add to us
+                }
+            }
+        }
+
+        internal static void Deserialize(Stream stream, object target, Type type)
+        {
+            model.DeserializeWithLengthPrefix(stream, target, type, PrefixStyle.Base128, 0);
+        }
+    }
+}


### PR DESCRIPTION
### Changes made in this pull request

  - Added SMLProtobufSerializer

Adding this to SMLHelper allows modders to, instead of reinventing serialization when wanting to save their objects in game, Simply make use of the game's Protobuf implementation and serialize each object in their specific chunks, As handled by the game's code.