### PR TITLE
CraftTreeControl

### DIFF
--- a/SMLHelper/Assets/CustomFabricator.cs
+++ b/SMLHelper/Assets/CustomFabricator.cs
@@ -119,9 +119,14 @@
         public virtual Color ColorTint => Color.white;
 
         /// <summary>
-        /// The ID value for your custom craft tree. This is set in the <see cref="CreateCustomCraftTree(out CraftTree.Type)"/> method.
+        /// The ID value for your custom craft tree. This is set after this <see cref="Spawnable.Patch"/> method is invoked.
         /// </summary>
         public CraftTree.Type TreeTypeID { get; private set; }
+
+        /// <summary>
+        /// Gets the root node of the crafting tree. This is set after this <see cref="Spawnable.Patch"/> method is invoked.
+        /// </summary>
+        public ModCraftTreeRoot Root { get; private set; }
 
         /// <summary>
         /// Override with the category within the group in the PDA blueprints where this item appears.
@@ -131,7 +136,7 @@
         /// <summary>
         /// Override with the main group in the PDA blueprints where this item appears.
         /// </summary>
-        public override TechGroup GroupForPDA => TechGroup.InteriorModules;        
+        public override TechGroup GroupForPDA => TechGroup.InteriorModules;
 
         /// <summary>
         /// The in-game <see cref="GameObject"/>.
@@ -228,7 +233,7 @@
         {
             throw new NotImplementedException($"To use a custom fabricator model, the prefab must be created in {nameof(GetCustomCrafterPreFab)}.");
         }
-        
+
         /// <summary>
         /// Override this method if you want full control over how your custom craft tree is built up.<para/>
         /// To use this method's default behavior, you must use the following methods to build up your crafting tree.<para/>
@@ -240,6 +245,7 @@
         internal virtual void CreateCustomCraftTree(out CraftTree.Type craftTreeType)
         {
             ModCraftTreeRoot root = CraftTreeHandler.CreateCustomCraftTreeAndType(this.ClassID, out craftTreeType);
+            this.Root = root;
             CraftTreeLinkingNodes.Add(RootNode, root);
 
             // Since we shouldn't rely on attached events to be executed in any particular order,

--- a/SMLHelper/Crafting/ModCraftTreeRoot.cs
+++ b/SMLHelper/Crafting/ModCraftTreeRoot.cs
@@ -2,10 +2,14 @@
 {
     using System;
     using Patchers;
+    using SMLHelper.V2.Handlers;
     using UnityEngine.Assertions;
 
     /// <summary>
-    /// The root node of a CraftTree. The whole tree starts here.
+    /// The root node of a CraftTree. The whole tree starts here.<para/>
+    /// Build up your custom crafting tree from this root node using the AddCraftingNode and AddTabNode methods.<br/>
+    /// This tree will be automatically patched into the game. No further calls into <see cref="CraftTreeHandler"/> required.<para/>
+    /// For more advanced usage, you can replace the default value of <see cref="CraftTreeCreation"/> with your own custom function.        
     /// </summary>    
     /// <seealso cref="ModCraftTreeLinkingNode" />
     public class ModCraftTreeRoot : ModCraftTreeLinkingNode
@@ -24,13 +28,15 @@
             _schemeAsString = schemeAsString;
             _scheme = scheme;
             HasCustomTrees = true;
+
+            CraftTreeCreation = () => new CraftTree(_schemeAsString, CraftNode);
         }
 
         /// <summary>
         /// Dynamically creates the CraftTree object for this crafting tree.
         /// The CraftNode objects were created and linked as the classes of the ModCraftTreeFamily were created and linked.
         /// </summary>
-        internal CraftTree CraftTree => new CraftTree(_schemeAsString, CraftNode);
+        internal CraftTree CustomCraftingTree => CraftTreeCreation.Invoke();
 
         /// <summary>
         /// Populates a new ModCraftTreeRoot from a CraftNode tree.
@@ -53,13 +59,17 @@
                     var techType = TechType.None;
                     TechTypeExtensions.FromString(node.id, out techType, false);
 
-                    if (node.id == "SeamothHullModule2") techType = TechType.VehicleHullModule2;
-                    else if (node.id == "SeamothHullModule3") techType = TechType.VehicleHullModule3;
-
                     root.AddCraftingNode(techType);
                 }
             }
         }
+
+        /// <summary>
+        /// The craft tree creation function.<br/>
+        /// Default implementaion returns a new <see cref="CraftTree"/> instantiated with <see cref="SchemeAsString"/> and the root <see cref="CraftNode"/>.<para/>
+        /// You can replace this function with your own to have more control of the crafting tree when it is being created.
+        /// </summary>
+        public Func<CraftTree> CraftTreeCreation;
 
         /// <summary>
         /// Gets the tab node at the specified path from the root.

--- a/SMLHelper/Handlers/CraftTreeHandler.cs
+++ b/SMLHelper/Handlers/CraftTreeHandler.cs
@@ -25,15 +25,16 @@
         #region Static Methods
 
         /// <summary>
-        /// <para>Your first method call to start a new custom crafting tree.</para>
-        /// <para>Creating a new CraftTree only makes sense if you're going to use it in a new type of <see cref="GhostCrafter"/>.</para>
+        /// Your first method call to start a new custom crafting tree.<br/>
+        /// Creating a new CraftTree only makes sense if you're going to use it in a new type of <see cref="GhostCrafter"/>.
         /// </summary>
         /// <param name="name">The name for the new <see cref="CraftTree.Type" /> enum.</param>
         /// <param name="craftTreeType">The new enum instance for your custom craft tree type.</param>
         /// <returns>
-        /// <para>Returns the root node for your custom craft tree, as a new <see cref="ModCraftTreeRoot"/> instance.</para>
-        /// <para>Build up your custom crafting tree from this root node.</para>
-        /// <para>This tree will be automatically patched into the game. No further calls into <see cref="CraftTreeHandler"/> required.</para>
+        /// Returns the root node for your custom craft tree, as a new <see cref="ModCraftTreeRoot"/> instance.<br/>
+        /// Build up your custom crafting tree from this root node.<br/>
+        /// This tree will be automatically patched into the game. No further calls into <see cref="CraftTreeHandler"/> required.<para/>
+        /// For more advanced usage, you can replace the default value of <see cref="ModCraftTreeRoot.CraftTreeCreation"/> with your own custom function.        
         /// </returns>
         /// <seealso cref="ModCraftTreeNode"/>
         /// <seealso cref="ModCraftTreeLinkingNode"/>
@@ -168,15 +169,16 @@
         #region Interface Methods
 
         /// <summary>
-        /// <para>Your first method call to start a new custom crafting tree.</para>
-        /// <para>Creating a new CraftTree only makes sense if you're going to use it in a new type of <see cref="GhostCrafter"/>.</para>
+        /// Your first method call to start a new custom crafting tree.<br/>
+        /// Creating a new CraftTree only makes sense if you're going to use it in a new type of <see cref="GhostCrafter"/>.
         /// </summary>
         /// <param name="name">The name for the new <see cref="CraftTree.Type" /> enum.</param>
         /// <param name="craftTreeType">The new enum instance for your custom craft tree type.</param>
         /// <returns>
-        /// <para>Returns the root node for your custom craft tree, as a new <see cref="ModCraftTreeRoot"/> instance.</para>
-        /// <para>Build up your custom crafting tree from this root node.</para>
-        /// <para>This tree will be automatically patched into the game. No further calls into <see cref="CraftTreeHandler"/> required.</para>
+        /// Returns the root node for your custom craft tree, as a new <see cref="ModCraftTreeRoot"/> instance.<br/>
+        /// Build up your custom crafting tree from this root node.<br/>
+        /// This tree will be automatically patched into the game. No further calls into <see cref="CraftTreeHandler"/> required.<para/>
+        /// For more advanced usage, you can replace the default value of <see cref="ModCraftTreeRoot.CraftTreeCreation"/> with your own custom function.        
         /// </returns>
         /// <seealso cref="ModCraftTreeNode"/>
         /// <seealso cref="ModCraftTreeLinkingNode"/>

--- a/SMLHelper/Interfaces/ICraftTreeHandler.cs
+++ b/SMLHelper/Interfaces/ICraftTreeHandler.cs
@@ -1,6 +1,7 @@
 ﻿namespace SMLHelper.V2.Interfaces
 {
     using Crafting;
+    using SMLHelper.V2.Handlers;
     using UnityEngine;
 
     /// <summary>
@@ -9,15 +10,16 @@
     public interface ICraftTreeHandler
     {
         /// <summary>
-        /// <para>Your first method call to start a new custom crafting tree.</para>
-        /// <para>Creating a new CraftTree only makes sense if you're going to use it in a new type of <see cref="GhostCrafter"/>.</para>
+        /// Your first method call to start a new custom crafting tree.<br/>
+        /// Creating a new CraftTree only makes sense if you're going to use it in a new type of <see cref="GhostCrafter"/>.
         /// </summary>
         /// <param name="name">The name for the new <see cref="CraftTree.Type" /> enum.</param>
         /// <param name="craftTreeType">The new enum instance for your custom craft tree type.</param>
         /// <returns>
-        /// <para>Returns the root node for your custom craft tree, as a new <see cref="ModCraftTreeRoot"/> instance.</para>
-        /// <para>Build up your custom crafting tree from this root node.</para>
-        /// <para>This tree will be automatically patched into the game. No further calls into <see cref="ICraftTreeHandler"/> required.</para>
+        /// Returns the root node for your custom craft tree, as a new <see cref="ModCraftTreeRoot"/> instance.<br/>
+        /// Build up your custom crafting tree from this root node.<br/>
+        /// This tree will be automatically patched into the game. No further calls into <see cref="CraftTreeHandler"/> required.<para/>
+        /// For more advanced usage, you can replace the default value of <see cref="ModCraftTreeRoot.CraftTreeCreation"/> with your own custom function.        
         /// </returns>
         /// <seealso cref="ModCraftTreeNode"/>
         /// <seealso cref="ModCraftTreeLinkingNode"/>

--- a/SMLHelper/Patchers/CraftTreePatcher.cs
+++ b/SMLHelper/Patchers/CraftTreePatcher.cs
@@ -54,7 +54,7 @@
         {
             if (CustomTrees.ContainsKey(treeType))
             {
-                __result = CustomTrees[treeType].CraftTree;
+                __result = CustomTrees[treeType].CustomCraftingTree;
                 return false;
             }
 
@@ -67,7 +67,7 @@
             {
                 foreach (CraftTree.Type cTreeKey in CustomTrees.Keys)
                 {
-                    CraftTree customTree = CustomTrees[cTreeKey].CraftTree;
+                    CraftTree customTree = CustomTrees[cTreeKey].CustomCraftingTree;
 
                     MethodInfo addToCraftableTech = AccessTools.Method(typeof(CraftTree), nameof(CraftTree.AddToCraftableTech));
 


### PR DESCRIPTION
### **Enables mods to fully control their custom CraftTree whenever it is created**

Other changes
- Removes old checks for Seamoth upgrade modules from EarlyAccess
- Renamed the internal, get-only property `CraftTree` to `CustomCraftingTree` to avoid ambiguity in the documentation of `CraftTreeCreation`.
- Updated XML documentation.
- Added documentation to `ModCraftTreeRoot` for discoverability of this new feature.
