### PR TITLE
SMLHelper 2.6.1

### DIFF
--- a/SMLHelper/Handlers/CraftDataHandler_Subnautica.cs
+++ b/SMLHelper/Handlers/CraftDataHandler_Subnautica.cs
@@ -234,41 +234,38 @@ namespace SMLHelper.V2.Handlers
         /// <returns>Returns TechData if it exists; Otherwise, returns <c>null</c>.</returns>
         TechData ICraftDataHandler.GetTechData(TechType techType)
         {
-
             if (CraftDataPatcher.CustomTechData.TryGetValue(techType, out ITechData iTechData))
             {
-                TechData techData = new TechData() {craftAmount = iTechData.craftAmount};
-
-                for(int i = 0; i < iTechData.ingredientCount; i++)
-                {
-                    IIngredient ingredient = iTechData.GetIngredient(i);
-                    Ingredient smlingredient = new Ingredient(ingredient.techType, ingredient.amount);
-                    techData.Ingredients.Add(smlingredient);
-                }
-                for (int i = 0; i < iTechData.linkedItemCount; i++)
-                {
-                    techData.LinkedItems.Add(iTechData.GetLinkedItem(i));
-                }
-                return techData;
+                return ConvertToTechData(iTechData);
             }
 
             iTechData = CraftData.Get(techType, true);
-            if(iTechData != null)
+
+            if (iTechData != null)
             {
-                TechData techData = new TechData() { craftAmount = iTechData.craftAmount };
-                for (int i = 0; i < iTechData.ingredientCount; i++)
-                {
-                    IIngredient ingredient = iTechData.GetIngredient(i);
-                    Ingredient smlingredient = new Ingredient(ingredient.techType, ingredient.amount);
-                    techData.Ingredients.Add(smlingredient);
-                }
-                for (int i = 0; i < iTechData.linkedItemCount; i++)
-                {
-                    techData.LinkedItems.Add(iTechData.GetLinkedItem(i));
-                }
-                return techData;
+                return ConvertToTechData(iTechData);
             }
+
             return null;
+        }
+
+        private static TechData ConvertToTechData(ITechData iTechData)
+        {
+            var techData = new TechData() { craftAmount = iTechData.craftAmount };
+
+            for (int i = 0; i < iTechData.ingredientCount; i++)
+            {
+                IIngredient ingredient = iTechData.GetIngredient(i);
+                var smlingredient = new Ingredient(ingredient.techType, ingredient.amount);
+                techData.Ingredients.Add(smlingredient);
+            }
+
+            for (int i = 0; i < iTechData.linkedItemCount; i++)
+            {
+                techData.LinkedItems.Add(iTechData.GetLinkedItem(i));
+            }
+
+            return techData;
         }
 
         #endregion

--- a/SMLHelper/Handlers/CraftDataHandler_Subnautica.cs
+++ b/SMLHelper/Handlers/CraftDataHandler_Subnautica.cs
@@ -235,36 +235,36 @@ namespace SMLHelper.V2.Handlers
         TechData ICraftDataHandler.GetTechData(TechType techType)
         {
 
-            if (CraftDataPatcher.CustomTechData.TryGetValue(techType, out ITechData moddedTechData))
+            if (CraftDataPatcher.CustomTechData.TryGetValue(techType, out ITechData iTechData))
             {
-                TechData techData = new TechData() {craftAmount = moddedTechData.craftAmount};
+                TechData techData = new TechData() {craftAmount = iTechData.craftAmount};
 
-                for(int i = 0; i < moddedTechData.ingredientCount; i++)
+                for(int i = 0; i < iTechData.ingredientCount; i++)
                 {
-                    IIngredient ingredient = moddedTechData.GetIngredient(i);
+                    IIngredient ingredient = iTechData.GetIngredient(i);
                     Ingredient smlingredient = new Ingredient(ingredient.techType, ingredient.amount);
                     techData.Ingredients.Add(smlingredient);
                 }
-                for (int i = 0; i < moddedTechData.linkedItemCount; i++)
+                for (int i = 0; i < iTechData.linkedItemCount; i++)
                 {
-                    techData.LinkedItems.Add(moddedTechData.GetLinkedItem(i));
+                    techData.LinkedItems.Add(iTechData.GetLinkedItem(i));
                 }
                 return techData;
             }
 
-            ITechData td = CraftData.Get(techType, true);
-            if(td != null)
+            iTechData = CraftData.Get(techType, true);
+            if(iTechData != null)
             {
-                TechData techData = new TechData() { craftAmount = td.craftAmount };
-                for (int i = 0; i < td.ingredientCount; i++)
+                TechData techData = new TechData() { craftAmount = iTechData.craftAmount };
+                for (int i = 0; i < iTechData.ingredientCount; i++)
                 {
-                    IIngredient ingredient = td.GetIngredient(i);
+                    IIngredient ingredient = iTechData.GetIngredient(i);
                     Ingredient smlingredient = new Ingredient(ingredient.techType, ingredient.amount);
                     techData.Ingredients.Add(smlingredient);
                 }
-                for (int i = 0; i < td.linkedItemCount; i++)
+                for (int i = 0; i < iTechData.linkedItemCount; i++)
                 {
-                    techData.LinkedItems.Add(moddedTechData.GetLinkedItem(i));
+                    techData.LinkedItems.Add(iTechData.GetLinkedItem(i));
                 }
                 return techData;
             }

--- a/SMLHelper/Handlers/TechTypeHandler.cs
+++ b/SMLHelper/Handlers/TechTypeHandler.cs
@@ -317,7 +317,7 @@
         /// </remarks>
         bool ITechTypeHandler.TryGetModdedTechType(string techtypeString, out TechType modTechType)
         {
-            EnumTypeCache cache = TechTypePatcher.cacheManager.RequestCacheForTypeName(techtypeString);
+            EnumTypeCache cache = TechTypePatcher.cacheManager.RequestCacheForTypeName(techtypeString, false);
 
             if (cache != null) // Item Found
             {
@@ -344,7 +344,7 @@
         /// </remarks>
         bool ITechTypeHandler.ModdedTechTypeExists(string techtypeString)
         {
-            EnumTypeCache cache = TechTypePatcher.cacheManager.RequestCacheForTypeName(techtypeString);
+            EnumTypeCache cache = TechTypePatcher.cacheManager.RequestCacheForTypeName(techtypeString, false);
             return cache != null;
         }
 

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.6.0.0")]
-[assembly: AssemblyFileVersion("2.6.0.0")]
+[assembly: AssemblyVersion("2.6.1.0")]
+[assembly: AssemblyFileVersion("2.6.1.0")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/Utility/EnumCacheManager.cs
+++ b/SMLHelper/Utility/EnumCacheManager.cs
@@ -266,7 +266,7 @@
             }
         }
 
-        internal EnumTypeCache RequestCacheForTypeName(string name)
+        internal EnumTypeCache RequestCacheForTypeName(string name, bool checkDeactivated = true)
         {
             LoadCache();
 
@@ -279,7 +279,7 @@
                 entriesFromRequests.Add(value, name);
                 return new EnumTypeCache(value, name);
             }
-            else if (entriesFromDeactivatedFile.TryGetValue(name, out value))
+            else if (checkDeactivated && entriesFromDeactivatedFile.TryGetValue(name, out value))
             {
                 entriesFromRequests.Add(value, name);
                 entriesFromDeactivatedFile.Remove(value, name);

--- a/SMLHelper/Utility/ImageUtils.cs
+++ b/SMLHelper/Utility/ImageUtils.cs
@@ -60,7 +60,7 @@
         /// <returns>Will return a new <see cref="Atlas.Sprite"/> instance if the file exists; Otherwise returns null.</returns>
         public static Atlas.Sprite LoadSpriteFromFile(string filePathToImage, TextureFormat format = TextureFormat.BC7)
         {
-            Texture2D texture2D = LoadTextureFromFile(filePathToImage, TextureFormat.BC7);
+            Texture2D texture2D = LoadTextureFromFile(filePathToImage, format);
 
             return new Atlas.Sprite(texture2D);
         }

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "Modding Helper (SMLHelper)",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.6.0",
+    "Version": "2.6.1",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll"

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper (Modding Helper)",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.6.0",
+    "Version": "2.6.1",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll"


### PR DESCRIPTION

### Changes made in this pull request
- Fixed a Null Ref Exception when trying to get unmodified/vanilla TechData from `GetTechData`.
- `ModdedTechTypeExists` and `TryGetModdedTechType` no longer return `true` for deactivated TechTypes
- Optional `format` parameter for `LoadSpriteFromFile` in Subnautica now handled