### PR TITLE
Custom eating sounds

### DIFF
--- a/SMLHelper/Handlers/CraftDataHandler_Subnautica.cs
+++ b/SMLHelper/Handlers/CraftDataHandler_Subnautica.cs
@@ -10,7 +10,6 @@ namespace SMLHelper.V2.Handlers
     /// </summary>
     public partial class CraftDataHandler : ICraftDataHandler
     {
-
         #region Subnautica Specific Static Methods
 
         /// <summary>
@@ -59,6 +58,25 @@ namespace SMLHelper.V2.Handlers
         public static TechData GetTechData(TechType techType)
         {
             return Main.GetTechData(techType);
+        }
+
+        /// <summary>
+        /// Sets the eating sound for the provided TechType.
+        /// </summary>
+        /// <param name="consumable">The item being consumed during <see cref="Survival.Eat(UnityEngine.GameObject)"/>.</param>
+        /// <param name="soundPath">
+        /// The sound path.
+        /// <para>
+        /// Value values are
+        /// - "event:/player/drink"
+        /// - "event:/player/drink_stillsuit"
+        /// - "event:/player/use_first_aid"
+        /// - "event:/player/eat" (default)
+        /// </para>
+        /// </param>
+        public static void SetEatingSound(TechType consumable, string soundPath)
+        {
+            Main.SetEatingSound(consumable, soundPath);
         }
 
         #endregion
@@ -266,6 +284,25 @@ namespace SMLHelper.V2.Handlers
             }
 
             return techData;
+        }
+
+        /// <summary>
+        /// Sets the eating sound for the provided TechType.
+        /// </summary>
+        /// <param name="consumable">The item being consumed during <see cref="Survival.Eat(UnityEngine.GameObject)"/>.</param>
+        /// <param name="soundPath">
+        /// The sound path.
+        /// <para>
+        /// Value values are
+        /// - "event:/player/drink"
+        /// - "event:/player/drink_stillsuit"
+        /// - "event:/player/use_first_aid"
+        /// - "event:/player/eat" (default)
+        /// </para>
+        /// </param>
+        void ICraftDataHandler.SetEatingSound(TechType consumable, string soundPath)
+        {
+            CraftDataPatcher.CustomEatingSounds.Add(consumable, soundPath);
         }
 
         #endregion

--- a/SMLHelper/Interfaces/ICraftDataHandler_Subnautica.cs
+++ b/SMLHelper/Interfaces/ICraftDataHandler_Subnautica.cs
@@ -40,6 +40,22 @@ namespace SMLHelper.V2.Interfaces
         /// <param name="techType">The TechType whose TechData you want to access.</param>
         /// <returns>Returns TechData if it exists; Otherwise, returns <c>null</c>.</returns>
         TechData GetTechData(TechType techType);
+
+        /// <summary>
+        /// Sets the eating sound for the provided TechType.
+        /// </summary>
+        /// <param name="consumable">The item being consumed during <see cref="Survival.Eat(UnityEngine.GameObject)"/>.</param>
+        /// <param name="soundPath">
+        /// The sound path.
+        /// <para>
+        /// Value values are
+        /// - "event:/player/drink"
+        /// - "event:/player/drink_stillsuit"
+        /// - "event:/player/use_first_aid"
+        /// - "event:/player/eat" (default)
+        /// </para>
+        /// </param>
+        void SetEatingSound(TechType consumable, string soundPath);
     }
 }
 #endif

--- a/SMLHelper/Patchers/CraftDataPatcher_Subnautica.cs
+++ b/SMLHelper/Patchers/CraftDataPatcher_Subnautica.cs
@@ -26,89 +26,74 @@ namespace SMLHelper.V2.Patchers
 
         private static void PatchForSubnautica(HarmonyInstance harmony)
         {
-            harmony.Patch(AccessTools.Method(typeof(CraftData), nameof(CraftData.Get)),
-               prefix: new HarmonyMethod(AccessTools.Method(typeof(CraftDataPatcher), nameof(NeedsPatchingCheckPrefix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftData), nameof(CraftData.GetHarvestOutputData)),
-               prefix: new HarmonyMethod(AccessTools.Method(typeof(CraftDataPatcher), nameof(GetHarvestOutputPrefix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftData), nameof(CraftData.GetHarvestTypeFromTech)),
-               prefix: new HarmonyMethod(AccessTools.Method(typeof(CraftDataPatcher), nameof(GetHarvestTypePrefix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftData), nameof(CraftData.GetHarvestFinalCutBonus)),
-               prefix: new HarmonyMethod(AccessTools.Method(typeof(CraftDataPatcher), nameof(GetFinalCutBonusPrefix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftData), nameof(CraftData.GetItemSize)),
-               prefix: new HarmonyMethod(AccessTools.Method(typeof(CraftDataPatcher), nameof(GetItemSizePrefix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftData), nameof(CraftData.GetEquipmentType)),
-               prefix: new HarmonyMethod(AccessTools.Method(typeof(CraftDataPatcher), nameof(GetEquipmentTypePrefix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftData), nameof(CraftData.GetQuickSlotType)),
-               prefix: new HarmonyMethod(AccessTools.Method(typeof(CraftDataPatcher), nameof(GetSlotTypePrefix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftData), nameof(CraftData.GetCraftTime)),
-               prefix: new HarmonyMethod(AccessTools.Method(typeof(CraftDataPatcher), nameof(GetCraftTimePrefix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftData), nameof(CraftData.GetCookedData)),
-               prefix: new HarmonyMethod(AccessTools.Method(typeof(CraftDataPatcher), nameof(GetCookedCreaturePrefix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftData), nameof(CraftData.GetBackgroundType)),
-               prefix: new HarmonyMethod(AccessTools.Method(typeof(CraftDataPatcher), nameof(GetBackgroundTypesPrefix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftData), nameof(CraftData.IsBuildableTech)),
-               prefix: new HarmonyMethod(AccessTools.Method(typeof(CraftDataPatcher), nameof(GetBuildablePrefix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftData), nameof(CraftData.GetUseEatSound)),
-               prefix: new HarmonyMethod(AccessTools.Method(typeof(CraftDataPatcher), nameof(GetUseEatSoundPrefix))));
-
+            PatchUtils.PatchClass(harmony);
         }
 
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(CraftData), nameof(CraftData.GetHarvestOutputData))]
         private static void GetHarvestOutputPrefix(TechType techType)
         {
             DictionaryPrefix(techType, CustomHarvestOutputList, CraftData.harvestOutputList);
         }
 
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(CraftData), nameof(CraftData.GetHarvestTypeFromTech))]
         private static void GetHarvestTypePrefix(TechType techType)
         {
             DictionaryPrefix(techType, CustomHarvestTypeList, CraftData.harvestTypeList);
         }
 
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(CraftData), nameof(CraftData.GetHarvestFinalCutBonus))]
         private static void GetFinalCutBonusPrefix(TechType techType)
         {
             DictionaryPrefix(techType, CustomFinalCutBonusList, CraftData.harvestFinalCutBonusList);
         }
 
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(CraftData), nameof(CraftData.GetItemSize))]
         private static void GetItemSizePrefix(TechType techType)
         {
             DictionaryPrefix(techType, CustomItemSizes, CraftData.itemSizes);
         }
 
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(CraftData), nameof(CraftData.GetEquipmentType))]
         private static void GetEquipmentTypePrefix(TechType techType)
         {
             DictionaryPrefix(techType, CustomEquipmentTypes, CraftData.equipmentTypes);
         }
 
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(CraftData), nameof(CraftData.GetQuickSlotType))]
         private static void GetSlotTypePrefix(TechType techType)
         {
             DictionaryPrefix(techType, CustomSlotTypes, CraftData.slotTypes);
         }
 
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(CraftData), nameof(CraftData.GetCraftTime))]
         private static void GetCraftTimePrefix(TechType techType)
         {
             DictionaryPrefix(techType, CustomCraftingTimes, CraftData.craftingTimes);
         }
 
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(CraftData), nameof(CraftData.GetCookedData))]
         private static void GetCookedCreaturePrefix(TechType techType)
         {
             DictionaryPrefix(techType, CustomCookedCreatureList, CraftData.cookedCreatureList);
         }
 
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(CraftData), nameof(CraftData.GetBackgroundType))]
         private static void GetBackgroundTypesPrefix(TechType techType)
         {
             DictionaryPrefix(techType, CustomBackgroundTypes, CraftData.backgroundTypes);
         }
 
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(CraftData), nameof(CraftData.GetUseEatSound))]
         private static void GetUseEatSoundPrefix(TechType techType)
         {
             DictionaryPrefix(techType, CustomEatingSounds, CraftData.useEatSound);
@@ -130,12 +115,16 @@ namespace SMLHelper.V2.Patchers
             }
         }
 
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(CraftData), nameof(CraftData.IsBuildableTech))]
         private static void GetBuildablePrefix(TechType recipe)
         {
             if (CustomBuildables.Contains(recipe) && !CraftData.buildables.Contains(recipe))
                 PatchUtils.PatchList(CraftData.buildables, CustomBuildables);
         }
 
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(CraftData), nameof(CraftData.Get))]
         private static void NeedsPatchingCheckPrefix(TechType techType)
         {
             bool techExists = CraftData.techData.TryGetValue(techType, out CraftData.TechData techData);

--- a/SMLHelper/Patchers/CraftDataPatcher_Subnautica.cs
+++ b/SMLHelper/Patchers/CraftDataPatcher_Subnautica.cs
@@ -66,160 +66,66 @@ namespace SMLHelper.V2.Patchers
 
         private static void GetHarvestOutputPrefix(TechType techType)
         {
-            if (CustomHarvestOutputList.TryGetValue(techType, out TechType smlho))
-            {
-                if(CraftData.harvestOutputList.TryGetValue(techType, out TechType tt))
-                {
-                    if(smlho != tt)
-                        CraftData.harvestOutputList[techType] = smlho;
-                }
-                else
-                {
-                    PatchUtils.PatchDictionary(CraftData.harvestOutputList, CustomHarvestOutputList);
-                }
-            }
+            DictionaryPrefix(techType, CustomHarvestOutputList, CraftData.harvestOutputList);
         }
 
         private static void GetHarvestTypePrefix(TechType techType)
         {
-            if (CustomHarvestTypeList.TryGetValue(techType, out HarvestType smlht))
-            {
-                if (CraftData.harvestTypeList.TryGetValue(techType, out HarvestType ht))
-                {
-                    if (ht != smlht)
-                        CraftData.harvestTypeList[techType] = smlht;
-                }
-                else
-                {
-                    PatchUtils.PatchDictionary(CraftData.harvestTypeList, CustomHarvestTypeList);
-                }
-            }
+            DictionaryPrefix(techType, CustomHarvestTypeList, CraftData.harvestTypeList);
         }
 
         private static void GetFinalCutBonusPrefix(TechType techType)
         {
-            if (CustomFinalCutBonusList.TryGetValue(techType, out int smlhfcb))
-            {
-                if (CraftData.harvestFinalCutBonusList.TryGetValue(techType, out int hfcb))
-                {
-                    if (hfcb != smlhfcb)
-                        CraftData.harvestFinalCutBonusList[techType] = smlhfcb;
-                }
-                else
-                {
-                    PatchUtils.PatchDictionary(CraftData.harvestFinalCutBonusList, CustomFinalCutBonusList);
-                }
-            }
+            DictionaryPrefix(techType, CustomFinalCutBonusList, CraftData.harvestFinalCutBonusList);
         }
 
         private static void GetItemSizePrefix(TechType techType)
         {
-            if(CustomItemSizes.TryGetValue(techType, out Vector2int smlItemSize))
-            {
-                if(CraftData.itemSizes.TryGetValue(techType, out Vector2int itemSize))
-                {
-                    if (smlItemSize.x != itemSize.x || smlItemSize.y != itemSize.y)
-                        CraftData.itemSizes[techType] = smlItemSize;
-                }
-                else
-                {
-                    PatchUtils.PatchDictionary(CraftData.itemSizes, CustomItemSizes);
-                }
-            }
+            DictionaryPrefix(techType, CustomItemSizes, CraftData.itemSizes);
         }
 
         private static void GetEquipmentTypePrefix(TechType techType)
         {
-            if (CustomEquipmentTypes.TryGetValue(techType, out EquipmentType SMLET))
-            {
-                if (CraftData.equipmentTypes.TryGetValue(techType, out EquipmentType ET))
-                {
-                    if (ET != SMLET)
-                        CraftData.equipmentTypes[techType] = SMLET;
-                }
-                else
-                {
-                    PatchUtils.PatchDictionary(CraftData.equipmentTypes, CustomEquipmentTypes);
-                }
-            }
+            DictionaryPrefix(techType, CustomEquipmentTypes, CraftData.equipmentTypes);
         }
 
         private static void GetSlotTypePrefix(TechType techType)
         {
-            if (CustomSlotTypes.TryGetValue(techType, out QuickSlotType smlqst))
-            {
-                if (CraftData.slotTypes.TryGetValue(techType, out QuickSlotType qst))
-                {
-                    if (qst != smlqst)
-                        CraftData.slotTypes[techType] = smlqst;
-                }
-                else
-                {
-                    PatchUtils.PatchDictionary(CraftData.slotTypes, CustomSlotTypes);
-                }
-            }
+            DictionaryPrefix(techType, CustomSlotTypes, CraftData.slotTypes);
         }
 
         private static void GetCraftTimePrefix(TechType techType)
         {
-            if (CustomCraftingTimes.TryGetValue(techType, out float smlct))
-            {
-                if (CraftData.craftingTimes.TryGetValue(techType, out float ct))
-                {
-                    if (ct != smlct)
-                        CraftData.craftingTimes[techType] = smlct;
-                }
-                else
-                {
-                    PatchUtils.PatchDictionary(CraftData.craftingTimes, CustomCraftingTimes);
-                }
-            }
+            DictionaryPrefix(techType, CustomCraftingTimes, CraftData.craftingTimes);
         }
 
         private static void GetCookedCreaturePrefix(TechType techType)
         {
-            if (CustomCookedCreatureList.TryGetValue(techType, out TechType smltt))
-            {
-                if (CraftData.cookedCreatureList.TryGetValue(techType, out TechType tt))
-                {
-                    if (tt != smltt)
-                        CraftData.cookedCreatureList[techType] = smltt;
-                }
-                else
-                {
-                    PatchUtils.PatchDictionary(CraftData.cookedCreatureList, CustomCookedCreatureList);
-                }
-            }
+            DictionaryPrefix(techType, CustomCookedCreatureList, CraftData.cookedCreatureList);
         }
 
         private static void GetBackgroundTypesPrefix(TechType techType)
         {
-            if (CustomBackgroundTypes.TryGetValue(techType, out CraftData.BackgroundType smlbt))
-            {
-                if (CraftData.backgroundTypes.TryGetValue(techType, out CraftData.BackgroundType bt))
-                {
-                    if (bt != smlbt)
-                        CraftData.backgroundTypes[techType] = smlbt;
-                }
-                else
-                {
-                    PatchUtils.PatchDictionary(CraftData.backgroundTypes, CustomBackgroundTypes);
-                }
-            }
+            DictionaryPrefix(techType, CustomBackgroundTypes, CraftData.backgroundTypes);
         }
 
         private static void GetUseEatSoundPrefix(TechType techType)
         {
-            if (CustomEatingSounds.TryGetValue(techType, out string smlsoundPath))
+            DictionaryPrefix(techType, CustomEatingSounds, CraftData.useEatSound);
+        }
+
+        private static void DictionaryPrefix<T>(TechType techType, IDictionary<TechType, T> smlCollection, IDictionary<TechType, T> craftDataCollection)
+        {
+            if (smlCollection.TryGetValue(techType, out T sml))
             {
-                if (CraftData.useEatSound.TryGetValue(techType, out string soundPath))
+                if (craftDataCollection.TryGetValue(techType, out T gameVal))
                 {
-                    if (smlsoundPath != soundPath)
-                        CraftData.useEatSound[techType] = smlsoundPath;
+                    if (!sml.Equals(gameVal))
+                        craftDataCollection[techType] = sml;
                 }
                 else
                 {
-                    PatchUtils.PatchDictionary(CraftData.useEatSound, CustomEatingSounds);
+                    PatchUtils.PatchDictionary(craftDataCollection, smlCollection);
                 }
             }
         }

--- a/SMLHelper/Utility/PatchUtils.cs
+++ b/SMLHelper/Utility/PatchUtils.cs
@@ -8,7 +8,7 @@
 
     internal static class PatchUtils
     {
-        internal static void PatchDictionary<KeyType, ValueType>(Dictionary<KeyType, ValueType> original, IDictionary<KeyType, ValueType> patches)
+        internal static void PatchDictionary<KeyType, ValueType>(IDictionary<KeyType, ValueType> original, IDictionary<KeyType, ValueType> patches)
         {
             foreach (KeyValuePair<KeyType, ValueType> entry in patches)
             {
@@ -16,7 +16,7 @@
             }
         }
 
-        internal static void PatchList<ValueType>(List<ValueType> original, IList<ValueType> patches)
+        internal static void PatchList<ValueType>(IList<ValueType> original, IList<ValueType> patches)
         {
             foreach (ValueType entry in patches)
             {


### PR DESCRIPTION
### Changes made in this pull request
- Adds a new `SetEatingSound` method to the `CraftDataHandler`
 - Enables easy access to the existing eating sounds
 - Will allow modded drink items to use the drink sound instead of the eat sound _(no more crunchy water)_
 - Refactors lots of redundant code in the patcher class handling the dictionary patches of `CraftData`
