### PR TITLE
Remove craft tree node safely

### DIFF
--- a/SMLHelper/Patchers/CraftTreePatcher.cs
+++ b/SMLHelper/Patchers/CraftTreePatcher.cs
@@ -20,36 +20,13 @@
 
         internal static void Patch(HarmonyInstance harmony)
         {
-            harmony.Patch(AccessTools.Method(typeof(CraftTree), nameof(CraftTree.GetTree)),
-                prefix: new HarmonyMethod(AccessTools.Method(typeof(CraftTreePatcher), nameof(CraftTreePatcher.GetTreePreFix))));
+            PatchUtils.PatchClass(harmony);
 
-            harmony.Patch(AccessTools.Method(typeof(CraftTree), nameof(CraftTree.Initialize)),
-                postfix: new HarmonyMethod(AccessTools.Method(typeof(CraftTreePatcher), nameof(CraftTreePatcher.InitializePostFix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftTree), nameof(CraftTree.FabricatorScheme)),
-                postfix: new HarmonyMethod(AccessTools.Method(typeof(CraftTreePatcher), nameof(CraftTreePatcher.FabricatorSchemePostfix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftTree), nameof(CraftTree.ConstructorScheme)),
-                postfix: new HarmonyMethod(AccessTools.Method(typeof(CraftTreePatcher), nameof(CraftTreePatcher.ConstructorSchemePostfix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftTree), nameof(CraftTree.WorkbenchScheme)),
-                postfix: new HarmonyMethod(AccessTools.Method(typeof(CraftTreePatcher), nameof(CraftTreePatcher.WorkbenchSchemePostfix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftTree), nameof(CraftTree.SeamothUpgradesScheme)),
-                postfix: new HarmonyMethod(AccessTools.Method(typeof(CraftTreePatcher), nameof(CraftTreePatcher.SeamothUpgradesSchemePostfix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftTree), nameof(CraftTree.MapRoomSheme)),
-                postfix: new HarmonyMethod(AccessTools.Method(typeof(CraftTreePatcher), nameof(CraftTreePatcher.MapRoomSchemePostfix))));
-
-            harmony.Patch(AccessTools.Method(typeof(CraftTree), nameof(CraftTree.CyclopsFabricatorScheme)),
-                postfix: new HarmonyMethod(AccessTools.Method(typeof(CraftTreePatcher), nameof(CraftTreePatcher.CyclopsFabricatorSchemePostfix))));
-#if BELOWZERO
-            harmony.Patch(AccessTools.Method(typeof(CraftTree), nameof(CraftTree.SeaTruckFabricatorScheme)),
-                postfix: new HarmonyMethod(AccessTools.Method(typeof(CraftTreePatcher), nameof(CraftTreePatcher.SeaTruckFabricatorSchemePostfix))));
-#endif
             Logger.Log($"CraftTreePatcher is done.", LogLevel.Debug);
         }
 
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(CraftTree), nameof(CraftTree.GetTree))]
         private static bool GetTreePreFix(CraftTree.Type treeType, ref CraftTree __result)
         {
             if (CustomTrees.ContainsKey(treeType))
@@ -61,6 +38,8 @@
             return true;
         }
 
+        [PatchUtils.Postfix]
+        [HarmonyPatch(typeof(CraftTree), nameof(CraftTree.Initialize))]
         private static void InitializePostFix()
         {
             if (CraftTree.initialized && !ModCraftTreeNode.Initialized)
@@ -76,44 +55,58 @@
             }
         }
 
+        [PatchUtils.Postfix]
+        [HarmonyPatch(typeof(CraftTree), nameof(CraftTree.FabricatorScheme))]
         private static void FabricatorSchemePostfix(ref CraftNode __result)
         {
             PatchCraftTree(ref __result, CraftTree.Type.Fabricator);
         }
 
+        [PatchUtils.Postfix]
+        [HarmonyPatch(typeof(CraftTree), nameof(CraftTree.ConstructorScheme))]
         private static void ConstructorSchemePostfix(ref CraftNode __result)
         {
             PatchCraftTree(ref __result, CraftTree.Type.Constructor);
         }
 
+        [PatchUtils.Postfix]
+        [HarmonyPatch(typeof(CraftTree), nameof(CraftTree.WorkbenchScheme))]
         private static void WorkbenchSchemePostfix(ref CraftNode __result)
         {
             PatchCraftTree(ref __result, CraftTree.Type.Workbench);
         }
 
+        [PatchUtils.Postfix]
+        [HarmonyPatch(typeof(CraftTree), nameof(CraftTree.SeamothUpgradesScheme))]
         private static void SeamothUpgradesSchemePostfix(ref CraftNode __result)
         {
             PatchCraftTree(ref __result, CraftTree.Type.SeamothUpgrades);
         }
 
+        [PatchUtils.Postfix]
+        [HarmonyPatch(typeof(CraftTree), nameof(CraftTree.MapRoomSheme))]
         private static void MapRoomSchemePostfix(ref CraftNode __result)
         {
             PatchCraftTree(ref __result, CraftTree.Type.MapRoom);
         }
 
+        [PatchUtils.Postfix]
+        [HarmonyPatch(typeof(CraftTree), nameof(CraftTree.CyclopsFabricatorScheme))]
         private static void CyclopsFabricatorSchemePostfix(ref CraftNode __result)
         {
             PatchCraftTree(ref __result, CraftTree.Type.CyclopsFabricator);
         }
 
 #if BELOWZERO
+        [PatchUtils.Postfix]
+        [HarmonyPatch(typeof(CraftTree), nameof(CraftTree.SeaTruckFabricatorScheme))]
         private static void SeaTruckFabricatorSchemePostfix(ref CraftNode __result)
         {
             PatchCraftTree(ref __result, CraftTree.Type.SeaTruckFabricator);
         }
 #endif
 
-#endregion
+        #endregion
 
         #region Handling Nodes
 

--- a/SMLHelper/Patchers/CraftTreePatcher.cs
+++ b/SMLHelper/Patchers/CraftTreePatcher.cs
@@ -203,6 +203,12 @@
                 if (nodeToRemove.Scheme != scheme)
                     continue;
 
+                if (nodeToRemove.Path == null || nodeToRemove.Path.Length == 0)
+                {
+                    Logger.Warn($"An empty path in {nameof(RemoveNodes)} for '{scheme}' was skipped");
+                    continue;
+                }
+
                 // Get the names of each node in the path to traverse tree until we reach the node we want.
                 TreeNode currentNode = default;
                 currentNode = nodes;
@@ -220,14 +226,18 @@
                     currentNode = currentNode[currentPath];
                 }
 
-                // Hold a reference to the parent node
-                TreeNode parentNode = currentNode.parent;
-
                 // Safty checks.
                 if (currentNode != null && currentNode.id == currentPath)
                 {
-                    currentNode.Clear(); // Remove all child nodes (if any)
-                    parentNode.RemoveNode(currentNode); // Remove the node
+                    if (currentNode.parent == null)
+                    {
+                        Logger.Warn($"Skipped removing craft tree node in {nameof(RemoveNodes)} for '{scheme}'. Could not identify the parent node.");
+                    }
+                    else
+                    {
+                        currentNode.Clear(); // Remove all child nodes (if any)
+                        currentNode.parent.RemoveNode(currentNode); // Remove the node from its parent
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Changes made in this pull request

- Adds additional null checks and logging to avoid exceptions in the `RemoveNodes` method
- Applies PatchUtils attribute patching style to `CraftTreePatcher`
