### PR TITLE
Make it more clear how to use SetQuickSlotType.

### DIFF
--- a/SMLHelper/Handlers/CraftDataHandler.cs
+++ b/SMLHelper/Handlers/CraftDataHandler.cs
@@ -32,8 +32,8 @@
         }
 
         /// <summary>
-        /// <para>Allows you to edit QuickSlotType for TechTypes.</para>
-        /// <para>Can be used for existing TechTypes too.</para>
+        /// <para>Allows you to edit QuickSlotType for TechTypes. Can be used for existing TechTypes too.</para>
+        /// <para>Careful: This has to be called after the prefab registration.</para>
         /// </summary>
         /// <param name="techType">The TechType whose QuickSlotType you want to edit.</param>
         /// <param name="slotType">The QuickSlotType for that TechType.</param>

--- a/SMLHelper/Handlers/CraftDataHandler_BelowZero.cs
+++ b/SMLHelper/Handlers/CraftDataHandler_BelowZero.cs
@@ -284,8 +284,8 @@ namespace SMLHelper.V2.Handlers
         }
 
         /// <summary>
-        /// <para>Allows you to edit QuickSlotType for TechTypes.</para>
-        /// <para>Can be used for existing TechTypes too.</para>
+        /// <para>Allows you to edit QuickSlotType for TechTypes. Can be used for existing TechTypes too.</para>
+        /// <para>Careful: This has to be called after the prefab registration.</para>
         /// </summary>
         /// <param name="techType">The TechType whose QuickSlotType you want to edit.</param>
         /// <param name="slotType">The QuickSlotType for that TechType.</param>

--- a/SMLHelper/Handlers/CraftDataHandler_Subnautica.cs
+++ b/SMLHelper/Handlers/CraftDataHandler_Subnautica.cs
@@ -10,7 +10,7 @@ namespace SMLHelper.V2.Handlers
     /// </summary>
     public partial class CraftDataHandler : ICraftDataHandler
     {
-        #region Subnautica Specific Static Methods
+#region Subnautica Specific Static Methods
 
         /// <summary>
         /// <para>Allows you to edit recipes, i.e. TechData for TechTypes.</para>
@@ -79,9 +79,9 @@ namespace SMLHelper.V2.Handlers
             Main.SetEatingSound(consumable, soundPath);
         }
 
-        #endregion
+#endregion
 
-        #region Subnautica specific implementations
+#region Subnautica specific implementations
 
         /// <summary>
         /// <para>Allows you to edit recipes, i.e. TechData for TechTypes.</para>
@@ -119,8 +119,8 @@ namespace SMLHelper.V2.Handlers
         }
 
         /// <summary>
-        /// <para>Allows you to edit QuickSlotType for TechTypes.</para>
-        /// <para>Can be used for existing TechTypes too.</para>
+        /// <para>Allows you to edit QuickSlotType for TechTypes. Can be used for existing TechTypes too.</para>
+        /// <para>Careful: This has to be called after the prefab registration.</para>
         /// </summary>
         /// <param name="techType">The TechType whose QuickSlotType you want to edit.</param>
         /// <param name="slotType">The QuickSlotType for that TechType.</param>
@@ -305,7 +305,7 @@ namespace SMLHelper.V2.Handlers
             CraftDataPatcher.CustomEatingSounds.Add(consumable, soundPath);
         }
 
-        #endregion
+#endregion
     }
 }
 #endif

--- a/SMLHelper/Interfaces/ICraftDataHandler.cs
+++ b/SMLHelper/Interfaces/ICraftDataHandler.cs
@@ -14,8 +14,8 @@
         void SetEquipmentType(TechType techType, EquipmentType equipmentType);
 
         /// <summary>
-        /// <para>Allows you to edit QuickSlotType for TechTypes.</para>
-        /// <para>Can be used for existing TechTypes too.</para>
+        /// <para>Allows you to edit QuickSlotType for TechTypes. Can be used for existing TechTypes too.</para>
+        /// <para>Careful: This has to be called after the prefab registration.</para>
         /// </summary>
         /// <param name="techType">The TechType whose QuickSlotType you want to edit.</param>
         /// <param name="slotType">The QuickSlotType for that TechType.</param>


### PR DESCRIPTION
So I struggled the entire afternoon yesterday to discover that SetQuickSlotType has to be called last for it to work. I immediately informed MrPurple of the issue and now I'm just making a small PR to make it more clear how to use SetQuickSlotType for everyone. You could add a security check to make sure that people are calling SetQuickSlotType last but I don't think it's a good idea (better to let them know of the right order and let them take action in consequences).

### Changes made in this pull request
  - Added comments for usage clarification