### PR TITLE
Ability to register ping types via SML

### DIFF
--- a/SMLHelper/Handlers/PingHandler.cs
+++ b/SMLHelper/Handlers/PingHandler.cs
@@ -1,9 +1,12 @@
-﻿using SMLHelper.V2.Patchers;
-using UnityEngine;
-
-namespace SMLHelper.V2.Handlers
+﻿namespace SMLHelper.V2.Handlers
 {
+    using Patchers;
     using Interfaces;
+#if SUBNAUTICA
+    using Sprite = Atlas.Sprite;
+#elif BELOWZERO
+    using Sprite = UnityEngine.Sprite;
+#endif
 
     /// <summary>
     /// A handler related to PingTypes
@@ -18,37 +21,57 @@ namespace SMLHelper.V2.Handlers
         private PingHandler()
         {
         }
-
+        
         /// <summary>
         /// Registers a ping type for use when creating a beacon
         /// </summary>
         /// <param name="pingName">The name of the new ping type</param>
         /// <param name="sprite">The sprite that is associated with the ping</param>
         /// <returns>The newly registered PingType</returns>
-        public PingType RegisterNewPingType(string pingName, Sprite sprite)
+        public static PingType RegisterNewPingType(string pingName, Sprite sprite)
         {
-            return RegisterNewPingType(pingName, new Atlas.Sprite(sprite));   
+            return Main.RegisterNewPingType(pingName, sprite);
         }
 
+        /// <summary>
+        /// Safely looks for a modded ping type in the SMLHelper PingTypeCache and outputs its <see cref="PingType"/> value when found.
+        /// </summary>
+        /// <param name="pingTypeString">The string used to define the modded PingType</param>
+        /// <param name="moddedPingType">The PingType enum value. Defaults to <see cref="PingType.None"/> when the PingType was not found.</param>
+        /// <returns><c>True</c> if the PingType was found; Otherwise <c>false</c></returns>
+        public static bool TryGetModdedPingType(string pingTypeString, out PingType moddedPingType)
+        {
+            return Main.TryGetModdedPingType(pingTypeString, out moddedPingType);
+        }
+        
         /// <summary>
         /// Registers a ping type for use when creating a beacon
         /// </summary>
         /// <param name="pingName">The name of the new ping type</param>
         /// <param name="sprite">The sprite that is associated with the ping</param>
         /// <returns>The newly registered PingType</returns>
-        public PingType RegisterNewPingType(string pingName, Atlas.Sprite sprite)
+        PingType IPingHandler.RegisterNewPingType(string pingName, Sprite sprite)
         {
-            return PingTypePatcher.AddPingType(pingName, sprite);
+            return PingTypePatcher.AddPingType(pingName, sprite);   
         }
-
+        
         /// <summary>
-        /// Returns nullable containing a ping type associated with a name, if it exists.
+        /// Safely looks for a modded ping type in the SMLHelper PingTypeCache and outputs its <see cref="PingType"/> value when found.
         /// </summary>
-        /// <param name="pingName">The name associated with the PingType you want.</param>
-        /// <returns>A nullable containing a PingType if one was associated with the given pingName</returns>
-        public PingType? GetPingType(string pingName)
+        /// <param name="pingTypeString">The string used to define the modded PingType</param>
+        /// <param name="moddedPingType">The PingType enum value. Defaults to <see cref="PingType.None"/> when the PingType was not found.</param>
+        /// <returns><c>True</c> if the PingType was found; Otherwise <c>false</c></returns>
+        bool IPingHandler.TryGetModdedPingType(string pingTypeString, out PingType moddedPingType)
         {
-            return PingTypePatcher.GetPingType(pingName);
+            var cache = PingTypePatcher.cacheManager.RequestCacheForTypeName(pingTypeString, false);
+            if (cache != null)
+            {
+                moddedPingType = (PingType) cache.Index;
+                return true;
+            }
+
+            moddedPingType = PingType.None;
+            return false;
         }
     }
 }

--- a/SMLHelper/Handlers/PingHandler.cs
+++ b/SMLHelper/Handlers/PingHandler.cs
@@ -1,0 +1,54 @@
+﻿using SMLHelper.V2.Patchers;
+using UnityEngine;
+
+namespace SMLHelper.V2.Handlers
+{
+    using Interfaces;
+
+    /// <summary>
+    /// A handler related to PingTypes
+    /// </summary>
+    public class PingHandler : IPingHandler
+    {
+        /// <summary>
+        /// Main entry point for all calls to this handler.
+        /// </summary>
+        public static IPingHandler Main { get; } = new PingHandler();
+
+        private PingHandler()
+        {
+        }
+
+        /// <summary>
+        /// Registers a ping type for use when creating a beacon
+        /// </summary>
+        /// <param name="pingName">The name of the new ping type</param>
+        /// <param name="sprite">The sprite that is associated with the ping</param>
+        /// <returns>The newly registered PingType</returns>
+        public PingType RegisterNewPingType(string pingName, Sprite sprite)
+        {
+            return RegisterNewPingType(pingName, new Atlas.Sprite(sprite));   
+        }
+
+        /// <summary>
+        /// Registers a ping type for use when creating a beacon
+        /// </summary>
+        /// <param name="pingName">The name of the new ping type</param>
+        /// <param name="sprite">The sprite that is associated with the ping</param>
+        /// <returns>The newly registered PingType</returns>
+        public PingType RegisterNewPingType(string pingName, Atlas.Sprite sprite)
+        {
+            return PingTypePatcher.AddPingType(pingName, sprite);
+        }
+
+        /// <summary>
+        /// Returns nullable containing a ping type associated with a name, if it exists.
+        /// </summary>
+        /// <param name="pingName">The name associated with the PingType you want.</param>
+        /// <returns>A nullable containing a PingType if one was associated with the given pingName</returns>
+        public PingType? GetPingType(string pingName)
+        {
+            return PingTypePatcher.GetPingType(pingName);
+        }
+    }
+}

--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -74,6 +74,7 @@
             WorldEntityDatabasePatcher.Patch(harmony);
             IngameMenuPatcher.Patch(harmony);
             TooltipPatcher.Patch(harmony);
+            PingTypePatcher.Patch(harmony);
 
             Logger.Debug("Saving TechType Cache");
             TechTypePatcher.cacheManager.SaveCache();

--- a/SMLHelper/Interfaces/IPingHandler.cs
+++ b/SMLHelper/Interfaces/IPingHandler.cs
@@ -1,7 +1,11 @@
-﻿using System;
-
-namespace SMLHelper.V2.Interfaces
+﻿namespace SMLHelper.V2.Interfaces
 {
+#if SUBNAUTICA
+    using Sprite = Atlas.Sprite;
+#elif BELOWZERO
+    using Sprite = UnityEngine.Sprite;
+#endif
+    
     /// <summary>
     /// A handler related to PingTypes
     /// </summary>
@@ -13,21 +17,14 @@ namespace SMLHelper.V2.Interfaces
         /// <param name="pingName">The name of the new ping type</param>
         /// <param name="sprite">The sprite that is associated with the ping</param>
         /// <returns>The newly registered PingType</returns>
-        PingType RegisterNewPingType(string pingName, UnityEngine.Sprite sprite);
-        
-        /// <summary>
-        /// Registers a ping type for use when creating a beacon
-        /// </summary>
-        /// <param name="pingName">The name of the new ping type</param>
-        /// <param name="sprite">The sprite that is associated with the ping</param>
-        /// <returns>The newly registered PingType</returns>
-        PingType RegisterNewPingType(string pingName, Atlas.Sprite sprite);
+        PingType RegisterNewPingType(string pingName, Sprite sprite);
 
         /// <summary>
-        /// Returns nullable containing a ping type associated with a name, if it exists.
+        /// Safely looks for a modded ping type in the SMLHelper PingTypeCache and outputs its <see cref="PingType"/> value when found.
         /// </summary>
-        /// <param name="pingName">The name associated with the PingType you want.</param>
-        /// <returns>A nullable containing a PingType if one was associated with the given pingName</returns>
-        PingType? GetPingType(string pingName);
+        /// <param name="pingTypeString">The string used to define the modded PingType</param>
+        /// <param name="moddedPingType">The PingType enum value. Defaults to <see cref="PingType.None"/> when the PingType was not found.</param>
+        /// <returns><c>True</c> if the PingType was found; Otherwise <c>false</c></returns>
+        bool TryGetModdedPingType(string pingTypeString, out PingType moddedPingType);
     }
 }

--- a/SMLHelper/Interfaces/IPingHandler.cs
+++ b/SMLHelper/Interfaces/IPingHandler.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace SMLHelper.V2.Interfaces
+{
+    /// <summary>
+    /// A handler related to PingTypes
+    /// </summary>
+    public interface IPingHandler
+    {
+        /// <summary>
+        /// Registers a ping type for use when creating a beacon
+        /// </summary>
+        /// <param name="pingName">The name of the new ping type</param>
+        /// <param name="sprite">The sprite that is associated with the ping</param>
+        /// <returns>The newly registered PingType</returns>
+        PingType RegisterNewPingType(string pingName, UnityEngine.Sprite sprite);
+        
+        /// <summary>
+        /// Registers a ping type for use when creating a beacon
+        /// </summary>
+        /// <param name="pingName">The name of the new ping type</param>
+        /// <param name="sprite">The sprite that is associated with the ping</param>
+        /// <returns>The newly registered PingType</returns>
+        PingType RegisterNewPingType(string pingName, Atlas.Sprite sprite);
+
+        /// <summary>
+        /// Returns nullable containing a ping type associated with a name, if it exists.
+        /// </summary>
+        /// <param name="pingName">The name associated with the PingType you want.</param>
+        /// <returns>A nullable containing a PingType if one was associated with the given pingName</returns>
+        PingType? GetPingType(string pingName);
+    }
+}

--- a/SMLHelper/Patchers/PingTypePatcher.cs
+++ b/SMLHelper/Patchers/PingTypePatcher.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Harmony;
+using SMLHelper.V2.Handlers;
+using SMLHelper.V2.Utility;
+
+namespace SMLHelper.V2.Patchers
+{
+    internal class PingTypePatcher
+    {
+        private const string TechTypeEnumName = "PingType";
+        internal static readonly int startingIndex = 10;
+        internal static readonly List<int> bannedIndices = new List<int>();
+        private static readonly Dictionary<PingType, Atlas.Sprite> cachedSprites = new Dictionary<PingType, Atlas.Sprite>();
+
+        internal static readonly EnumCacheManager<PingType> cacheManager =
+            new EnumCacheManager<PingType>(
+                enumTypeName: TechTypeEnumName,
+                startingIndex: startingIndex,
+                bannedIDs: ExtBannedIdManager.GetBannedIdsFor(TechTypeEnumName, bannedIndices, PreRegisteredCraftTreeTypes()));
+
+        private static List<int> PreRegisteredCraftTreeTypes()
+        {
+            var declaredPingTypes = (PingType[]) Enum.GetValues(typeof(PingType));
+            var bannedIndices = declaredPingTypes.Select(t => (int) t)
+                .Where(t => t > startingIndex)
+                .Distinct()
+                .ToList();
+            
+            Logger.Log($"Finished known PingType exclusion. {bannedIndices.Count} IDs were added in ban list.");
+            return bannedIndices;
+        }
+
+        internal static PingType AddPingType(string name, Atlas.Sprite sprite)
+        {
+            var cache = cacheManager.RequestCacheForTypeName(name) ?? new EnumTypeCache()
+            {
+                Name = name,
+                Index = cacheManager.GetNextAvailableIndex()
+            };
+
+            if (cacheManager.IsIndexAvailable(cache.Index))
+                cache.Index = cacheManager.GetNextAvailableIndex();
+
+            var pingType = (PingType) cache.Index;
+            cacheManager.Add(pingType, cache.Index, cache.Name);
+            
+            cachedSprites.Add(pingType, sprite);
+            if (PingManager.sCachedPingTypeStrings.valueToString.ContainsKey(pingType) == false)
+                PingManager.sCachedPingTypeStrings.valueToString.Add(pingType, name);
+
+            if (PingManager.sCachedPingTypeTranslationStrings.valueToString.ContainsKey(pingType) == false)
+                PingManager.sCachedPingTypeTranslationStrings.valueToString.Add(pingType, name);
+            
+            Logger.Log($"Successfully added PingType: '{name}' to Index: '{cache.Index}'", LogLevel.Debug);
+            return pingType;
+        }
+
+        internal static PingType? GetPingType(string pingName)
+        {
+            try
+            {
+                var ping = Enum.Parse(typeof(PingType), pingName);
+                return (PingType) ping;
+            }
+            catch (ArgumentException e)
+            {
+                return new PingType?();
+            }
+        }
+        
+        internal static void Patch(HarmonyInstance harmony)
+        {
+            IngameMenuHandler.Main.RegisterOneTimeUseOnSaveEvent(() => cacheManager.SaveCache());
+
+            harmony.Patch(AccessTools.Method(typeof(Enum), nameof(Enum.GetValues)),
+                postfix: new HarmonyMethod(AccessTools.Method(typeof(PingTypePatcher), nameof(Postfix_GetValues))));
+
+            harmony.Patch(AccessTools.Method(typeof(Enum), nameof(Enum.IsDefined)),
+                prefix: new HarmonyMethod(AccessTools.Method(typeof(PingTypePatcher), nameof(Prefix_IsDefined))));
+
+            harmony.Patch(AccessTools.Method(typeof(Enum), nameof(Enum.Parse), new Type[] { typeof(Type), typeof(string), typeof(bool) }),
+                prefix: new HarmonyMethod(AccessTools.Method(typeof(PingTypePatcher), nameof(Prefix_Parse))));
+
+            harmony.Patch(AccessTools.Method(typeof(PingType), nameof(PingType.ToString), new Type[] { }),
+                prefix: new HarmonyMethod(AccessTools.Method(typeof(PingTypePatcher), nameof(Prefix_ToString))));
+            
+            harmony.Patch(AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.Get), new Type[] { typeof(SpriteManager.Group), typeof(string) }),
+                prefix: new HarmonyMethod(AccessTools.Method(typeof(PingTypePatcher), nameof(Prefix_SpriteManager_Get))));
+
+            Logger.Log($"Added {cacheManager.ModdedKeysCount} PingTypes succesfully into the game.");
+            Logger.Log("PingTypePatcher is done.", LogLevel.Debug);
+        }
+
+        private static bool Prefix_SpriteManager_Get(SpriteManager.Group group, string name, ref Atlas.Sprite __result)
+        {
+            if (group == SpriteManager.Group.Pings)
+            {
+                var pingType = GetPingType(name);
+                if (pingType.HasValue && cachedSprites.ContainsKey(pingType.Value))
+                {
+                    __result = cachedSprites[pingType.Value];
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        
+        private static void Postfix_GetValues(Type enumType, ref Array __result)
+        {
+            if (enumType == typeof(PingType))
+            {
+                __result = __result.Cast<PingType>().Concat(cacheManager.ModdedKeys).ToArray();
+            }
+        }
+        
+        private static bool Prefix_IsDefined(Type enumType, object value, ref bool __result)
+        {
+            var result = enumType == typeof(PingType) && cacheManager.ContainsKey((PingType) value);
+            __result |= result;
+            return !result;
+        }
+        
+        private static bool Prefix_Parse(Type enumType, string value, bool ignoreCase, ref object __result)
+        {
+            if (enumType == typeof(PingType) && cacheManager.TryParse(value, out var pingType))
+            {
+                __result = pingType;
+                return false;
+            }
+
+            return true;
+        }
+        
+        private static bool Prefix_ToString(Enum __instance, ref string __result)
+        {
+            if (__instance is PingType pingType)
+            {
+                if (cacheManager.TryGetValue(pingType, out var pingTypeName))
+                {
+                    __result = pingTypeName;
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/SMLHelper/Patchers/SpritePatcher.cs
+++ b/SMLHelper/Patchers/SpritePatcher.cs
@@ -59,5 +59,11 @@
             Logger.Error("SpritePatcher was unable to find a sprite dictionary");
             return null;
         }
+
+        internal static void AddSprite(SpriteManager.Group group, string spriteName, Sprite sprite)
+        {
+            var spriteGroup = GetSpriteGroup(group);
+            spriteGroup.Add(spriteName, sprite);
+        }
     }
 }

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -147,6 +147,8 @@
     <Compile Include="Crafting\TabNode.cs" />
     <Compile Include="Crafting\RecipeData.cs" />
     <Compile Include="Crafting\TechData.cs" />
+    <Compile Include="Handlers\PingHandler.cs" />
+    <Compile Include="Interfaces\IPingHandler.cs" />
     <Compile Include="Json\Converters\FloatConverter.cs" />
     <Compile Include="Json\ExtensionMethods\JsonExtensions.cs" />
     <Compile Include="Handler.cs" />
@@ -216,6 +218,7 @@
     <Compile Include="Patchers\OptionsPanelPatcher.cs" />
     <Compile Include="Patchers\PDAEncyclopediaPatcher.cs" />
     <Compile Include="Patchers\PDAPatcher.cs" />
+    <Compile Include="Patchers\PingTypePatcher.cs" />
     <Compile Include="Patchers\PrefabDatabasePatcher.cs" />
     <Compile Include="Patchers\SpritePatcher.cs" />
     <Compile Include="Patchers\TechTypePatcher.cs" />


### PR DESCRIPTION
Ability to register new ping types via SML helper

### Changes made in this pull request

- PingHandler which has a `RegisterNewPingType` and `GetPingType` methods
- `RegisterNewType` is responsible for taking a name of a PingType and a Sprite and creating a PingType enum. It also inserts the Sprite into a collection which when `SpriteManager.Get` is called with `SpriteManager.Group.Pings` will check that collection.
- `GetPingType` is just a wrapper around `Enum.Parse` which handles if you give it an invalid name.

 
