### PR TITLE
ToolTipBugFix

### DIFF
--- a/SMLHelper/Patchers/TooltipPatcher.cs
+++ b/SMLHelper/Patchers/TooltipPatcher.cs
@@ -106,10 +106,7 @@
 
         internal static bool IsVanillaTechType(TechType type)
         {
-            DisableEnumIsDefinedPatch = true;
-            bool result = Enum.IsDefined(typeof(TechType), type);
-            DisableEnumIsDefinedPatch = false;
-            return result;
+            return type <= TechType.Databox;
         }
 
         #region Options


### PR DESCRIPTION
- Fixes the tooltip bug that is misidentifying all items as vanilla items
- `DisableEnumIsDefinedPatch` was no longer in use