### PR TITLE
Fix FloatConverter... again

### DIFF
--- a/SMLHelper/Json/Converters/FloatConverter.cs
+++ b/SMLHelper/Json/Converters/FloatConverter.cs
@@ -49,7 +49,7 @@
         {
             if (DecimalPlaces > -1)
             {
-                writer.WriteValue(Math.Round((double)value, DecimalPlaces, Mode).ToString(CultureInfo.InvariantCulture));
+                writer.WriteValue(Math.Round(Convert.ToDouble(value), DecimalPlaces, Mode).ToString(CultureInfo.InvariantCulture));
             }
             else
             {


### PR DESCRIPTION
### Changes made in this pull request

My bad. I should have tested this more thoroughly.

We actually need to use `Convert.ToDouble(value)` explicitly instead of `(double)value` here: when the original boxed `object` was type `float`, using `(double)value` here to cast it fails. But `Convert.ToDouble(value)` works in either case.

That, or we could instead go back to:

```csharp
if (value is float floatValue) {
    // round the float to specified decimal places and convert to string
}
else
{
    // if it's not a float, it's a double... so cast to double, round do decimal places, convert to string
}
```