### PR TITLE
Strip Unnecessarily Exposed Newtonsoft.Json Classes from ConfigFile API

### DIFF
--- a/Example mod/Example mod.csproj
+++ b/Example mod/Example mod.csproj
@@ -37,10 +37,6 @@
       <HintPath>..\Dependencies\Subnautica\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\Dependencies\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="QModInstaller">
       <HintPath>..\Dependencies\Subnautica\QModInstaller.dll</HintPath>
       <Private>False</Private>

--- a/SMLHelper/Json/ConfigFile.cs
+++ b/SMLHelper/Json/ConfigFile.cs
@@ -8,6 +8,7 @@
     using SMLHelper.V2.Json.Interfaces;
     using Oculus.Newtonsoft.Json;
     using Oculus.Newtonsoft.Json.Converters;
+    using SMLHelper.V2.Utility;
 
     /// <summary>
     /// A simple implementation of <see cref="IJsonFile"/> for use with config files.
@@ -20,7 +21,7 @@
         public string JsonFilePath { get; private set; }
 
         [JsonIgnore]
-        private readonly JsonConverter[] alwaysIncludedJsonConverters = new JsonConverter[] {
+        private static JsonConverter[] alwaysIncludedJsonConverters = new JsonConverter[] {
             new KeyCodeConverter(),
             new FloatConverter(),
             new StringEnumConverter(),
@@ -70,10 +71,29 @@
         /// </summary>
         /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
         /// already exist.</param>
+        /// <seealso cref="Save()"/>
+        /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
+        public void Load(bool createFileIfNotExist = true)
+            => this.LoadJson(JsonFilePath, createFileIfNotExist, AlwaysIncludedJsonConverters.Distinct().ToArray());
+
+        /// <summary>
+        /// Saves the current fields and properties of the <see cref="ConfigFile"/> as JSON properties to the file on disk.
+        /// </summary>
+        /// <seealso cref="Load(bool)"/>
+        /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
+        public void Save() => this.SaveJson(JsonFilePath,
+            AlwaysIncludedJsonConverters.Distinct().ToArray());
+
+        /// <summary>
+        /// Loads the JSON properties from the file on disk into the <see cref="ConfigFile"/>.
+        /// </summary>
+        /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
+        /// already exist.</param>
         /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for serialization.
         /// The <see cref="AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
-        /// <seealso cref="Save(JsonConverter[])"/>
-        public void Load(bool createFileIfNotExist = true, params JsonConverter[] jsonConverters)
+        /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
+        /// <seealso cref="Load(bool)"/>
+        public void LoadWithConverters(bool createFileIfNotExist = true, params JsonConverter[] jsonConverters)
             => this.LoadJson(JsonFilePath, true,
                 AlwaysIncludedJsonConverters.Concat(jsonConverters).Distinct().ToArray());
 
@@ -82,8 +102,9 @@
         /// </summary>
         /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for deserialization.
         /// The <see cref="AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
-        /// <seealso cref="Load(bool, JsonConverter[])"/>
-        public void Save(params JsonConverter[] jsonConverters)
+        /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
+        /// <seealso cref="Save"/>
+        public void SaveWithConverters(params JsonConverter[] jsonConverters)
             => this.SaveJson(JsonFilePath,
                 AlwaysIncludedJsonConverters.Concat(jsonConverters).Distinct().ToArray());
     }

--- a/SMLHelper/Json/ConfigFile.cs
+++ b/SMLHelper/Json/ConfigFile.cs
@@ -8,7 +8,6 @@
     using SMLHelper.V2.Json.Interfaces;
     using Oculus.Newtonsoft.Json;
     using Oculus.Newtonsoft.Json.Converters;
-    using SMLHelper.V2.Utility;
 
     /// <summary>
     /// A simple implementation of <see cref="IJsonFile"/> for use with config files.
@@ -21,7 +20,7 @@
         public string JsonFilePath { get; private set; }
 
         [JsonIgnore]
-        private static JsonConverter[] alwaysIncludedJsonConverters = new JsonConverter[] {
+        private static readonly JsonConverter[] alwaysIncludedJsonConverters = new JsonConverter[] {
             new KeyCodeConverter(),
             new FloatConverter(),
             new StringEnumConverter(),

--- a/SMLHelper/Json/Interfaces/IJsonFile.cs
+++ b/SMLHelper/Json/Interfaces/IJsonFile.cs
@@ -24,16 +24,34 @@
         /// </summary>
         /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
         /// already exist.</param>
+        /// <seealso cref="Save()"/>
+        /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
+        void Load(bool createFileIfNotExist = true);
+
+        /// <summary>
+        /// A method for saving the JSON properties to disk.
+        /// </summary>
+        /// <seealso cref="Load(bool)"/>
+        /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
+        void Save();
+
+        /// <summary>
+        /// A method for loading the JSON properties from disk.
+        /// </summary>
+        /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
+        /// already exist.</param>
         /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for
         /// deserialization.</param>
-        /// <seealso cref="Save(JsonConverter[])"/>
-        void Load(bool createFileIfNotExist = true, params JsonConverter[] jsonConverters);
+        /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
+        /// <seealso cref="Load(bool)"/>
+        void LoadWithConverters(bool createFileIfNotExist = true, params JsonConverter[] jsonConverters);
 
         /// <summary>
         /// A method for saving the JSON properties to disk.
         /// </summary>
         /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for serialization.</param>
-        /// <seealso cref="Load(bool, JsonConverter[])"/>
-        void Save(params JsonConverter[] jsonConverters);
+        /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
+        /// <seealso cref="Save"/>
+        void SaveWithConverters(params JsonConverter[] jsonConverters);
     }
 }


### PR DESCRIPTION
### Changes made in this pull request

- **Changed the ConfigFile API. Save() and Load() no longer expose `params JsonConverter[]`.**
This is a breaking change to any mods that were using that `params` array, however it is likely most were not, and they were all going to break with the upcoming change to the Newtonsoft.Json namespace anyway, and this PR should address that.

- **Mods using `ConfigFile` will no longer need to reference `Newtonsoft.Json.dll` if they are not directly interacting with classes from that file.**