### PR TITLE
Move Prefab Non Database Patches to PreInitialize.

### DIFF
--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -6,6 +6,7 @@
     using Patchers;
     using Patchers.EnumPatching;
     using QModManager.API.ModLoading;
+    using QModManager.Utility;
 
     /// <summary>
     /// WARNING: This class is for use only by QModManager.
@@ -14,6 +15,8 @@
     [Obsolete("This class is for use only by QModManager.", true)]
     public class Initializer
     {
+        private static Harmony harmony = new Harmony("com.ahk1221.smlhelper");
+
         /// <summary>
         /// WARNING: This method is for use only by QModManager.
         /// </summary>
@@ -32,6 +35,15 @@
             TechTypePatcher.cacheManager.LoadCache();
             Logger.Debug("Loading CraftTreeType Cache");
             CraftTreeTypePatcher.cacheManager.LoadCache();
+
+            try
+            {
+                PreInitialize();
+            }
+            catch(Exception e)
+            {
+                Logger.Error($"Caught exception while trying to initialize SMLHelper{Environment.NewLine}{e}");
+            }
         }
 
         /// <summary>
@@ -43,7 +55,7 @@
         {
             try
             {
-                Initialize();
+                PostInitialize();
             }
             catch (Exception e)
             {
@@ -51,10 +63,13 @@
             }
         }
 
-
-        private static void Initialize()
+        private static void PreInitialize()
         {
-            var harmony = new Harmony("com.ahk1221.smlhelper");
+            PrefabDatabasePatcher.PrePatch(harmony);
+        }
+
+        private static void PostInitialize()
+        {
 
             FishPatcher.Patch(harmony);
 
@@ -67,7 +82,7 @@
             CraftTreePatcher.Patch(harmony);
             DevConsolePatcher.Patch(harmony);
             LanguagePatcher.Patch(harmony);
-            PrefabDatabasePatcher.Patch(harmony);
+            PrefabDatabasePatcher.PostPatch(harmony);
             SpritePatcher.Patch();
             KnownTechPatcher.Patch(harmony);
             BioReactorPatcher.Patch();

--- a/SMLHelper/Patchers/PrefabDatabasePatcher.cs
+++ b/SMLHelper/Patchers/PrefabDatabasePatcher.cs
@@ -29,6 +29,16 @@
             return true;
         }
 
+        internal static bool TryGetPrefabFilename_Prefix(string classId, ref string filename)
+        {
+            if (ModPrefab.TryGetFromClassId(classId, out ModPrefab prefab))
+            {
+                filename = prefab.PrefabFileName;
+                return false;
+            }
+            return true;
+        }
+
         internal static bool GetPrefabAsync_Prefix(ref IPrefabRequest __result, string classId)
         {
             if (ModPrefab.TryGetFromClassId(classId, out ModPrefab prefab))
@@ -42,18 +52,26 @@
             return true;
         }
 
-        internal static void Patch(Harmony harmony)
+        internal static void PrePatch(Harmony harmony)
         {
-            harmony.Patch(AccessTools.Method(typeof(PrefabDatabase), nameof(PrefabDatabase.LoadPrefabDatabase)),
-                postfix: new HarmonyMethod(AccessTools.Method(typeof(PrefabDatabasePatcher), nameof(PrefabDatabasePatcher.LoadPrefabDatabase_Postfix))));
-
             harmony.Patch(AccessTools.Method(typeof(PrefabDatabase), nameof(PrefabDatabase.GetPrefabForFilename)), 
                 prefix: new HarmonyMethod(AccessTools.Method(typeof(PrefabDatabasePatcher), nameof(PrefabDatabasePatcher.GetPrefabForFilename_Prefix))));
+
+            harmony.Patch(AccessTools.Method(typeof(PrefabDatabase), nameof(PrefabDatabase.TryGetPrefabFilename)),
+                prefix: new HarmonyMethod(AccessTools.Method(typeof(PrefabDatabasePatcher), nameof(PrefabDatabasePatcher.TryGetPrefabFilename_Prefix))));
 
             harmony.Patch(AccessTools.Method(typeof(PrefabDatabase), nameof(PrefabDatabase.GetPrefabAsync)),
                 prefix: new HarmonyMethod(AccessTools.Method(typeof(PrefabDatabasePatcher), nameof(PrefabDatabasePatcher.GetPrefabAsync_Prefix))));
 
             Logger.Log("PrefabDatabasePatcher is done.", LogLevel.Debug);
+        }
+
+        internal static void PostPatch(Harmony harmony)
+        {
+            harmony.Patch(AccessTools.Method(typeof(PrefabDatabase), nameof(PrefabDatabase.LoadPrefabDatabase)),
+                postfix: new HarmonyMethod(AccessTools.Method(typeof(PrefabDatabasePatcher), nameof(PrefabDatabasePatcher.LoadPrefabDatabase_Postfix))));
+
+            Logger.Log("PrefabDatabasePostPatcher is done.", LogLevel.Debug);
         }
     }
 }

--- a/SMLHelper/Patchers/PrefabDatabasePatcher.cs
+++ b/SMLHelper/Patchers/PrefabDatabasePatcher.cs
@@ -29,11 +29,12 @@
             return true;
         }
 
-        internal static bool TryGetPrefabFilename_Prefix(string classId, ref string filename)
+        internal static bool TryGetPrefabFilename_Prefix(string classId, ref string filename, ref bool __result)
         {
             if (ModPrefab.TryGetFromClassId(classId, out ModPrefab prefab))
             {
                 filename = prefab.PrefabFileName;
+                __result = true;
                 return false;
             }
             return true;


### PR DESCRIPTION
Was driving myself crazy trying to make my new Customize Your Spawn mod working with modded techtypes when I realized that the reason it fails is because we don't patch these 3 prefab getters until after postPatch meaning I would have had to make my mod run AFTER SMLHelper for the prefabs to work.  

This keeps the current functionality of adding the prefabs to the base games code in meta post patch while still allowing mods to get the required information through the normal game code means...

### Changes made in this pull request

  - Created a Prefix patch for the lookup TryGetPrefabFilename to allow mods to get the required information to add modded items to the spawning system.
  - Moved the harmony patching of the getter methods to PrePatch so that mods trying to use them will correctly search the modded prefabs as well as the games prefabs
