### PR TITLE
Fix for Fixer

### DIFF
--- a/SMLHelper/Assets/ModPrefab.cs
+++ b/SMLHelper/Assets/ModPrefab.cs
@@ -81,28 +81,25 @@
             go.transform.position = new Vector3(-5000, -5000, -5000);
             go.name = this.ClassID;
 
-            /* Make sure prefab doesn't get cleared when quiting game to menu. */
-            SceneCleanerPreserve scp = go.AddComponent<SceneCleanerPreserve>();
-            scp.enabled = true;
-
             if (this.TechType != TechType.None)
             {
-                go.AddComponent<Fixer>().techType = this.TechType;
+                if (go.activeInHierarchy) // don't add Fixer to inactive prefabs
+                    go.AddComponent<Fixer>();
 
-                if (go.GetComponent<TechTag>() != null)
+                if (go.GetComponent<TechTag>() is TechTag tag)
                 {
-                    go.GetComponent<TechTag>().type = this.TechType;
+                    tag.type = this.TechType;
                 }
 
-                if (go.GetComponent<Constructable>() != null)
+                if (go.GetComponent<Constructable>() is Constructable cs)
                 {
-                    go.GetComponent<Constructable>().techType = this.TechType;
+                    cs.techType = this.TechType;
                 }
             }
 
-            if (go.GetComponent<PrefabIdentifier>() != null)
+            if (go.GetComponent<PrefabIdentifier>() is PrefabIdentifier pid)
             {
-                go.GetComponent<PrefabIdentifier>().ClassId = this.ClassID;
+                pid.ClassId = this.ClassID;
             }
 
             return go;

--- a/SMLHelper/MonoBehaviours/Fixer.cs
+++ b/SMLHelper/MonoBehaviours/Fixer.cs
@@ -7,61 +7,35 @@ namespace SMLHelper.V2.MonoBehaviours
     /// <summary>
     /// This <see cref="MonoBehaviour"/> is <c>automatically</c> added to any <see cref="GameObject"/> created through <see cref="ModPrefab.GetGameObject"/>.
     /// </summary>
-    public class Fixer : MonoBehaviour, IProtoEventListener
+    internal class Fixer : MonoBehaviour
     {
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-
-        [SerializeField]
-        public TechType techType;
-
-        [SerializeField]
-        public string ClassId;
-
         private float time;
-        private bool initalized;
+        private bool isPrefab => transform.position.y < -4500f;
 
-        private void Update()
+        public void Awake()
         {
-            if (!initalized)
-            {
-                time = Time.time + 1f;
-                initalized = true;
-            }
+            time = Time.time + 1f;
 
-            if (Time.time > time && this.gameObject != Builder.prefab)
-            {
-                if (this.transform.position.y < -4500)
-                {
-                    Logger.Debug("Destroying object: " + this.gameObject);
-                    Destroy(this.gameObject);
-                }
-                else
-                {
-                    Logger.Debug("Destroying Fixer for object: " + this.gameObject);
-                    Destroy(this);
-                }
-            }
+            // preventing LargeWorldEntity registration for prefabs (registered in LargeWorldEntity.Start)
+            if (gameObject.GetComponentInChildren<LargeWorldEntity>() is LargeWorldEntity lwe)
+                lwe.enabled = !isPrefab;
         }
 
-        public void OnProtoSerialize(ProtobufSerializer serializer)
+        public void Update()
         {
-        }
+            if (Time.time < time || gameObject == Builder.prefab)
+                return;
 
-        public void OnProtoDeserialize(ProtobufSerializer serializer)
-        {
-            Constructable constructable = GetComponent<Constructable>();
-            if (constructable != null)
+            if (isPrefab)
             {
-                constructable.techType = techType;
+                Logger.Debug("Destroying object: " + gameObject);
+                Destroy(gameObject);
             }
-
-            TechTag techTag = GetComponent<TechTag>();
-            if (techTag != null)
+            else
             {
-                techTag.type = techType;
+                Logger.Debug("Destroying Fixer for object: " + gameObject);
+                Destroy(this);
             }
         }
-
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }
 }


### PR DESCRIPTION
### Changes made in this pull request

  - `Fixer` is not adding to actual prefabs (e.g. loaded from asset bundles)
  - Prefab game object is not registered as `LargeWorldEntity` (registering only builded object now)
  - `IProtoEventListener` and its methods are removed from `Fixer`
  - `SceneCleanerPreserve` component is not adding to the prefab now