### PR TITLE
Asynchronous loading for ModPrefab

### DIFF
--- a/SMLHelper/Assets/ModPrefab.cs
+++ b/SMLHelper/Assets/ModPrefab.cs
@@ -1,6 +1,7 @@
 ﻿namespace SMLHelper.V2.Assets
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using UnityEngine;
 
@@ -71,12 +72,28 @@
         internal GameObject GetGameObjectInternal()
         {
             GameObject go = GetGameObject();
-
-            if (go == null)
-            {
+            if (!go)
                 return null;
-            }
 
+            ProcessPrefab(go);
+            return go;
+        }
+
+        internal IEnumerator GetGameObjectInternalAsync(IOut<GameObject> gameObject)
+        {
+            var taskResult = new TaskResult<GameObject>();
+            yield return GetGameObjectAsync(taskResult);
+
+            GameObject go = taskResult.Get();
+            if (!go)
+                yield break;
+
+            ProcessPrefab(go);
+            gameObject.Set(go);
+        }
+
+        private void ProcessPrefab(GameObject go)
+        {
             if (go.activeInHierarchy) // inactive prefabs don't need to be removed by cache
                 ModPrefabCache.AddPrefab(go);
 
@@ -99,15 +116,17 @@
             {
                 pid.ClassId = this.ClassID;
             }
-
-            return go;
         }
+
 
         /// <summary>
         /// Gets the prefab game object. Set up your prefab components here.
         /// The <see cref="TechType"/> and ClassID are already handled.
         /// </summary>
         /// <returns>The game object to be instantiated into a new in-game entity.</returns>
-        public abstract GameObject GetGameObject();
+        public virtual GameObject GetGameObject() => null; // SUBNAUTICA_EXP TODO: remove (or make obsolete) for SN after async update
+
+        /// <summary> TODO </summary>
+        public virtual IEnumerator GetGameObjectAsync(IOut<GameObject> gameObject) => null;
     }
 }

--- a/SMLHelper/Assets/ModPrefab.cs
+++ b/SMLHelper/Assets/ModPrefab.cs
@@ -72,7 +72,7 @@
         internal GameObject GetGameObjectInternal()
         {
             GameObject go = GetGameObject();
-            if (!go)
+            if (go == null)
                 return null;
 
             ProcessPrefab(go);
@@ -85,7 +85,7 @@
             yield return GetGameObjectAsync(taskResult);
 
             GameObject go = taskResult.Get();
-            if (!go)
+            if (go == null)
                 yield break;
 
             ProcessPrefab(go);
@@ -124,9 +124,13 @@
         /// The <see cref="TechType"/> and ClassID are already handled.
         /// </summary>
         /// <returns>The game object to be instantiated into a new in-game entity.</returns>
-        public virtual GameObject GetGameObject() => null; // SUBNAUTICA_EXP TODO: remove (or make obsolete) for SN after async update
+        public virtual GameObject GetGameObject() => null;
 
-        /// <summary> TODO </summary>
+        /// <summary>
+        /// Gets the prefab game object asynchronously. Set up your prefab components here.
+        /// The <see cref="TechType"/> and ClassID are already handled.
+        /// </summary>
+        /// <param name="gameObject"> The game object to be instantiated into a new in-game entity. </param>
         public virtual IEnumerator GetGameObjectAsync(IOut<GameObject> gameObject) => null;
     }
 }

--- a/SMLHelper/Assets/ModPrefabCache.cs
+++ b/SMLHelper/Assets/ModPrefabCache.cs
@@ -59,9 +59,23 @@
         public static void AddPrefab(GameObject prefab, bool autoremove = true)
         {
             Init();
-
             prefab.transform.parent = prefabRoot.transform;
 
+            AddPrefabInternal(prefab, autoremove);
+        }
+
+        /// <summary> TODO </summary>
+        public static GameObject AddPrefabCopy(GameObject prefab, bool autoremove = true)
+        {
+            Init();
+            var prefabCopy = UnityEngine.Object.Instantiate(prefab, prefabRoot.transform);
+
+            AddPrefabInternal(prefabCopy, autoremove);
+            return prefabCopy;
+        }
+
+        private static void AddPrefabInternal(GameObject prefab, bool autoremove)
+        {
             if (autoremove)
                 prefabs.Add(Tuple.Create(Time.time, prefab));
 

--- a/SMLHelper/Assets/ModPrefabCache.cs
+++ b/SMLHelper/Assets/ModPrefabCache.cs
@@ -64,7 +64,13 @@
             AddPrefabInternal(prefab, autoremove);
         }
 
-        /// <summary> TODO </summary>
+        /// <summary> Add prefab copy to cache (instatiated copy will not run 'Awake') </summary>
+        /// <param name="prefab"> Prefab to copy and add. </param>
+        /// <param name="autoremove">
+        /// Is prefab copy needed to be removed from cache after use.
+        /// Prefabs without autoremove flag can be safely deleted by <see cref="UnityEngine.Object.Destroy(UnityEngine.Object)" />
+        /// </param>
+        /// <returns> Prefab copy </returns>
         public static GameObject AddPrefabCopy(GameObject prefab, bool autoremove = true)
         {
             Init();

--- a/SMLHelper/Assets/ModPrefabRequest.cs
+++ b/SMLHelper/Assets/ModPrefabRequest.cs
@@ -9,6 +9,7 @@
     {
         private readonly ModPrefab modPrefab;
 
+        private int state = 0;
         private CoroutineTask<GameObject> task;
         private TaskResult<GameObject> taskResult;
 
@@ -44,7 +45,7 @@
         public bool MoveNext()
         {
             Init();
-            return task.GetResult() == null; // TODO: possible infinite loop ?
+            return state++ == 0;
         }
 
         public void Reset() {}

--- a/SMLHelper/Assets/ModPrefabRequest.cs
+++ b/SMLHelper/Assets/ModPrefabRequest.cs
@@ -1,0 +1,52 @@
+﻿namespace SMLHelper.V2.Assets
+{
+    using System.Collections;
+    using UnityEngine;
+    using UWE;
+
+    // request for getting ModPrefab asynchronously
+    internal class ModPrefabRequest: IPrefabRequest, IEnumerator
+    {
+        private readonly ModPrefab modPrefab;
+
+        private CoroutineTask<GameObject> task;
+        private TaskResult<GameObject> taskResult;
+
+        public ModPrefabRequest(ModPrefab modPrefab)
+        {
+            this.modPrefab = modPrefab;
+        }
+
+        private void Init()
+        {
+            if (task != null)
+                return;
+
+            taskResult = new TaskResult<GameObject>();
+            task = new CoroutineTask<GameObject>(modPrefab.GetGameObjectInternalAsync(taskResult), taskResult);
+        }
+
+        public object Current
+        {
+            get
+            {
+                Init();
+                return task;
+            }
+        }
+
+        public bool TryGetPrefab(out GameObject result)
+        {
+            result = taskResult.Get();
+            return result != null;
+        }
+
+        public bool MoveNext()
+        {
+            Init();
+            return task.GetResult() == null; // TODO: possible infinite loop ?
+        }
+
+        public void Reset() {}
+    }
+}

--- a/SMLHelper/Patchers/PrefabDatabasePatcher.cs
+++ b/SMLHelper/Patchers/PrefabDatabasePatcher.cs
@@ -1,82 +1,134 @@
 ﻿namespace SMLHelper.V2.Patchers
 {
+    using System;
+    using System.Reflection;
+    using System.Reflection.Emit;
+    using System.Collections;
+    using System.Collections.Generic;
+
     using Assets;
     using HarmonyLib;
-    using System.Reflection;
     using UnityEngine;
     using UWE;
     using Logger = V2.Logger;
 
-    internal class PrefabDatabasePatcher
+    internal static class PrefabDatabasePatcher
     {
-        private static MethodInfo tryGetPrefabFilename = AccessTools.Method(typeof(PrefabDatabase), nameof(PrefabDatabase.TryGetPrefabFilename));
-
-        internal static void LoadPrefabDatabase_Postfix()
+        private static class PostPatches
         {
-            foreach (ModPrefab prefab in ModPrefab.Prefabs)
+            [PatchUtils.Postfix]
+            [HarmonyPatch(typeof(PrefabDatabase), nameof(PrefabDatabase.LoadPrefabDatabase))]
+            internal static void LoadPrefabDatabase_Postfix()
             {
-                PrefabDatabase.prefabFiles[prefab.ClassID] = prefab.PrefabFileName;
-            }
+                foreach (ModPrefab prefab in ModPrefab.Prefabs)
+                {
+                    PrefabDatabase.prefabFiles[prefab.ClassID] = prefab.PrefabFileName;
+                }
 
-            Initializer.harmony.Unpatch(tryGetPrefabFilename, HarmonyPatchType.Prefix, Initializer.harmony.Id);
+                var tryGetPrefabFilename = AccessTools.Method(typeof(PrefabDatabase), nameof(PrefabDatabase.TryGetPrefabFilename));
+                Initializer.harmony.Unpatch(tryGetPrefabFilename, HarmonyPatchType.Prefix, Initializer.harmony.Id);
+            }
         }
 
-        internal static bool GetPrefabForFilename_Prefix(string filename, ref GameObject __result)
-        {
-            if (ModPrefab.TryGetFromFileName(filename, out ModPrefab prefab))
-            {
-                GameObject go = prefab.GetGameObjectInternal();
-                __result = go;
-
-                return false;
-            }
-
-            return true;
-        }
-
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(PrefabDatabase), nameof(PrefabDatabase.TryGetPrefabFilename))]
         internal static bool TryGetPrefabFilename_Prefix(string classId, ref string filename, ref bool __result)
         {
-            if (ModPrefab.TryGetFromClassId(classId, out ModPrefab prefab))
-            {
-                filename = prefab.PrefabFileName;
-                __result = true;
-                return false;
-            }
-            return true;
+            if (!ModPrefab.TryGetFromClassId(classId, out ModPrefab prefab))
+                return true;
+
+            filename = prefab.PrefabFileName;
+            __result = true;
+            return false;
         }
 
+        [PatchUtils.Prefix] // SUBNAUTICA_EXP TODO: remove for SN after async update
+        [HarmonyPatch(typeof(PrefabDatabase), "GetPrefabForFilename")] // method can be absent
+        internal static bool GetPrefabForFilename_Prefix(string filename, ref GameObject __result)
+        {
+            if (!ModPrefab.TryGetFromFileName(filename, out ModPrefab prefab))
+                return true;
+
+            __result = prefab.GetGameObjectInternal();
+            return false;
+        }
+
+        private static IPrefabRequest GetModPrefabAsync(string classId)
+        {
+            if (!ModPrefab.TryGetFromClassId(classId, out ModPrefab prefab))
+                return null;
+
+            try
+            {
+                // trying sync method for backward compatibility
+                if (prefab.GetGameObjectInternal() is GameObject go) // SUBNAUTICA_EXP TODO: remove for SN after async update
+                    return new LoadedPrefabRequest(go);
+            }
+            catch (Exception) {}
+
+            return new ModPrefabRequest(prefab);
+        }
+
+        [PatchUtils.Prefix]
+        [HarmonyPatch(typeof(PrefabDatabase), nameof(PrefabDatabase.GetPrefabAsync))]
         internal static bool GetPrefabAsync_Prefix(ref IPrefabRequest __result, string classId)
         {
-            if (ModPrefab.TryGetFromClassId(classId, out ModPrefab prefab))
-            { 
-                GameObject go = prefab.GetGameObjectInternal();
-                __result = new LoadedPrefabRequest(go);
+            __result ??= GetModPrefabAsync(classId);
+            return __result == null;
+        }
 
-                return false;
+
+        // transpiler for ProtobufSerializer.DeserializeObjectsAsync
+        private static IEnumerable<CodeInstruction> DeserializeObjectsAsync_Transpiler(IEnumerable<CodeInstruction> cins)
+        {
+            var originalMethod = AccessTools.Method(typeof(ProtobufSerializer), nameof(ProtobufSerializer.InstantiatePrefabAsync));
+
+            return new CodeMatcher(cins).
+                MatchForward(false, new CodeMatch(OpCodes.Call, originalMethod)).
+                SetOperandAndAdvance(AccessTools.Method(typeof(PrefabDatabasePatcher), nameof(_InstantiatePrefabAsync))).
+                InstructionEnumeration();
+        }
+
+        // calling this instead of InstantiatePrefabAsync in ProtobufSerializer.DeserializeObjectsAsync
+        private static IEnumerator _InstantiatePrefabAsync(ProtobufSerializer.GameObjectData gameObjectData, IOut<UniqueIdentifier> result)
+        {
+            if (GetModPrefabAsync(gameObjectData.ClassId) is IPrefabRequest request)
+            {
+                yield return request;
+
+                if (request.TryGetPrefab(out GameObject prefab))
+                {
+                    result.Set(UnityEngine.Object.Instantiate(prefab).GetComponent<UniqueIdentifier>());
+                    yield break;
+                }
             }
 
-            return true;
+            yield return ProtobufSerializer.InstantiatePrefabAsync(gameObjectData, result);
         }
+
 
         internal static void PrePatch(Harmony harmony)
         {
-#if !SUBNAUTICA_EXP // TODO
-            harmony.Patch(AccessTools.Method(typeof(PrefabDatabase), nameof(PrefabDatabase.GetPrefabForFilename)), 
-                prefix: new HarmonyMethod(AccessTools.Method(typeof(PrefabDatabasePatcher), nameof(PrefabDatabasePatcher.GetPrefabForFilename_Prefix))));
-#endif
-            harmony.Patch(tryGetPrefabFilename, prefix: new HarmonyMethod(AccessTools.Method(typeof(PrefabDatabasePatcher), nameof(PrefabDatabasePatcher.TryGetPrefabFilename_Prefix))));
+            PatchUtils.PatchClass(harmony);
 
-            harmony.Patch(AccessTools.Method(typeof(PrefabDatabase), nameof(PrefabDatabase.GetPrefabAsync)),
-                prefix: new HarmonyMethod(AccessTools.Method(typeof(PrefabDatabasePatcher), nameof(PrefabDatabasePatcher.GetPrefabAsync_Prefix))));
+            var obsoleteInstantiatePrefabAsync = AccessTools.Method(typeof(ProtobufSerializer), nameof(ProtobufSerializer.InstantiatePrefabAsync),
+                new[] { typeof(ProtobufSerializer.GameObjectData) });
+
+            if (obsoleteInstantiatePrefabAsync == null) // it means that we have async-only prefabs now, otherwise patch will fail
+            {
+                // patching iterator method ProtobufSerializer.DeserializeObjectsAsync
+                MethodInfo DeserializeObjectsAsync = typeof(ProtobufSerializer).GetMethod(
+                    nameof(ProtobufSerializer.DeserializeObjectsAsync), BindingFlags.NonPublic | BindingFlags.Instance);
+                harmony.Patch(PatchUtils.GetIteratorMethod(DeserializeObjectsAsync), transpiler:
+                    new HarmonyMethod(AccessTools.Method(typeof(PrefabDatabasePatcher), nameof(DeserializeObjectsAsync_Transpiler))));
+            }
 
             Logger.Log("PrefabDatabasePatcher is done.", LogLevel.Debug);
         }
 
         internal static void PostPatch(Harmony harmony)
         {
-            harmony.Patch(AccessTools.Method(typeof(PrefabDatabase), nameof(PrefabDatabase.LoadPrefabDatabase)),
-                postfix: new HarmonyMethod(AccessTools.Method(typeof(PrefabDatabasePatcher), nameof(PrefabDatabasePatcher.LoadPrefabDatabase_Postfix))));
-
+            PatchUtils.PatchClass(harmony, typeof(PostPatches));
 
             Logger.Log("PrefabDatabasePostPatcher is done.", LogLevel.Debug);
         }

--- a/SMLHelper/Patchers/PrefabDatabasePatcher.cs
+++ b/SMLHelper/Patchers/PrefabDatabasePatcher.cs
@@ -60,11 +60,14 @@
 
             try
             {
-                // trying sync method for backward compatibility
-                if (prefab.GetGameObjectInternal() is GameObject go) // SUBNAUTICA_EXP TODO: remove for SN after async update
+                // trying sync method first
+                if (prefab.GetGameObjectInternal() is GameObject go)
                     return new LoadedPrefabRequest(go);
             }
-            catch (Exception) {}
+            catch (Exception e)
+            {
+                Logger.Debug($"Caught exception while calling GetGameObject for {classId}, trying GetGameObjectAsync now. {Environment.NewLine}{e}");
+            }
 
             return new ModPrefabRequest(prefab);
         }

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Assets\FishPrefab.cs" />
     <Compile Include="Assets\ModPrefab.cs" />
     <Compile Include="Assets\ModPrefabCache.cs" />
+    <Compile Include="Assets\ModPrefabRequest.cs" />
     <Compile Include="Assets\SubnauticaModSprite.cs" />
     <Compile Include="Assets\BelowZeroModSprite.cs" />
     <Compile Include="Assets\PdaItem.cs" />


### PR DESCRIPTION
### Changes made in this pull request

**public changes:**
- asynchronous virtual method `IEnumerator GetGameObjectAsync(IOut<GameObject> gameObject)` added to the `ModPrefab`.
It is supposed to be used like `GetGameObject`, only all sync operations with game prefabs should be changed to async (examples will be added later).
- `AddPrefabCopy` method added to the `ModPrefabCache` class. It can be used for instantiating prefab and adding that copy to the cache at the same time. That way instantiated copy will not run `Awake()`, `Start()` and `Update()` in both sync and async versions of `GetGameObject`.

**internal changes:**
- `ModPrefabRequest` class added to the `SMLHelper.V2.Assets` namespace. It is used to get modded prefabs asynchronously (it calls `ModPrefab.GetGameObjectInternalAsync`)
- various changes in `PrefabDatabasePatcher` (new patch for object deserialization, using of `ModPrefabRequest` and some refactoring)

All new code supposed to work on both SN branches. Modders can add `GetGameObjectAsync` methods to their prefabs along with `GetGameObject`. For now, on the stable branch, `GetGameObjectAsync` doesn't do/break anything. And exp branch for now can be used to test `GetGameObjectAsync` (`GetGameObject` shouldn't break anything on exp branch).
So mods can be updated to use async prefabs ahead of update and when async update will hit stable branch, mods will not be broken (at least because of that).