### PR TITLE
BZ Stable Custom Crafter Null SkyApplier Fix

### DIFF
--- a/SMLHelper/Assets/CustomFabricator.cs
+++ b/SMLHelper/Assets/CustomFabricator.cs
@@ -271,7 +271,7 @@
             constructible.rotationEnabled = this.RotationEnabled;
             constructible.techType = this.TechType; // This was necessary to correctly associate the recipe at building time            
 
-            SkyApplier skyApplier = prefab.GetComponent<SkyApplier>();
+            SkyApplier skyApplier = prefab.EnsureComponent<SkyApplier>();
             skyApplier.renderers = prefab.GetComponentsInChildren<Renderer>();
             skyApplier.anchorSky = Skies.Auto;
 


### PR DESCRIPTION
Turns out that in BZ the Fabricator prefab does not originally contain a SkyApplier and so this was throwing a null exception. Changing to Ensure fixes this issue and works for both SN and BZ.

### Changes made in this pull request

  - Changed so that if the prefab does not have a skyApplier it does not cause a Null Exception.
