### PR TITLE
Prefab lookup null exception catch

### DIFF
--- a/SMLHelper/Assets/ModPrefab.cs
+++ b/SMLHelper/Assets/ModPrefab.cs
@@ -26,6 +26,11 @@
         internal static IEnumerable<ModPrefab> Prefabs => PreFabsList;
         internal static bool TryGetFromFileName(string classId, out ModPrefab prefab)
         {
+            if (string.IsNullOrEmpty(classId))
+            {
+                prefab = null;
+                return false;
+            }
             return FileNameDictionary.TryGetValue(classId, out prefab);
         }
 


### PR DESCRIPTION
  - Adds a Null check for the classId as somehow the game is passing a null into the prefab lookup which is breaking the initial game resource spawns
