### PR TITLE
SMLHelper 2.8.5 - Hotfix for `FloatConverter` globalisation issue.

### DIFF
--- a/SMLHelper/Json/Converters/FloatConverter.cs
+++ b/SMLHelper/Json/Converters/FloatConverter.cs
@@ -50,13 +50,14 @@
         /// <param name="serializer"></param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
+            double d = Convert.ToDouble(value);
             if (DecimalPlaces > -1)
             {
-                writer.WriteValue(Math.Round(Convert.ToDouble(value), DecimalPlaces, Mode).ToString(CultureInfo.InvariantCulture));
+                writer.WriteValue(Math.Round(d, DecimalPlaces, Mode).ToString(CultureInfo.InvariantCulture.NumberFormat));
             }
             else
             {
-                writer.WriteValue(value);
+                writer.WriteValue(d.ToString(CultureInfo.InvariantCulture.NumberFormat));
             }
         }
 
@@ -73,11 +74,11 @@
             var s = (string)reader.Value;
             if (objectType == typeof(float))
             {
-                return float.Parse(s);
+                return float.Parse(s, CultureInfo.InvariantCulture.NumberFormat);
             }
             else
             {
-                return double.Parse(s);
+                return double.Parse(s, CultureInfo.InvariantCulture.NumberFormat);
             }
         }
 

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.8.4.0")]
-[assembly: AssemblyFileVersion("2.8.4.0")]
+[assembly: AssemblyVersion("2.8.5.0")]
+[assembly: AssemblyFileVersion("2.8.5.0")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/Utility/JsonUtils.cs
+++ b/SMLHelper/Utility/JsonUtils.cs
@@ -69,9 +69,11 @@
                         serializedJson, jsonConverters
                     );
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     Logger.Announce($"Could not parse JSON file, loading default values: {path}", LogLevel.Warn, true);
+                    Logger.Error(ex.Message);
+                    Logger.Error(ex.StackTrace);
                     return new T();
                 }
             }

--- a/SMLHelper/Utility/JsonUtils.cs
+++ b/SMLHelper/Utility/JsonUtils.cs
@@ -120,9 +120,11 @@
                         serializedJson, jsonObject, jsonSerializerSettings
                     );
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     Logger.Announce($"Could not parse JSON file, instance values unchanged: {path}", LogLevel.Warn, true);
+                    Logger.Error(ex.Message);
+                    Logger.Error(ex.StackTrace);
                 }
             }
             else if (createFileIfNotExist)

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.8.4",
+    "Version": "2.8.5",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll"

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.8.4",
+    "Version": "2.8.5",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll"


### PR DESCRIPTION
## Changes made in this pull request
- Fixes a bug with `FloatConverter` not correctly reading JSON values from the invariant culture.
- Improved error logging when failing to parse JSON.