### PR TITLE
Pda Entry Data Overwriting

### DIFF
--- a/SMLHelper/Assets/PdaItem.cs
+++ b/SMLHelper/Assets/PdaItem.cs
@@ -22,7 +22,7 @@
 
         /// <summary>
         /// Override to add a scanner entry to the <see cref="RequiredForUnlock"/> TechType if it does not have one.
-        /// WARNING. You cannot add a scanner entry for a techtype that can already be scanned! 
+        /// WARNING. You can overwrite an existing entry with this. Use with Caution as this can break recipe unlocks of the original! 
         /// Default is <see langword="false"/>.
         /// </summary>
         public virtual bool AddScannerEntry => false;
@@ -47,7 +47,7 @@
 
         /// <summary>
         /// Override to add a <see cref="PDAEncyclopedia.EntryData"/> into the PDA's Encyclopedia for this object.
-        /// WARNING. You cannot overwrite an existing entry with this. It must have a unique key! 
+        /// WARNING. You can overwrite an existing entry with this. Use with Caution! 
         /// Default is <see langword="Null"/>.
         /// </summary>
         public virtual PDAEncyclopedia.EntryData EncyclopediaEntryData => null;

--- a/SMLHelper/Patchers/PDAEncyclopediaPatcher.cs
+++ b/SMLHelper/Patchers/PDAEncyclopediaPatcher.cs
@@ -1,6 +1,7 @@
 ﻿namespace SMLHelper.V2.Patchers
 {
     using HarmonyLib;
+    using SMLHelper.V2.Utility;
     using System.Collections.Generic;
 
     internal class PDAEncyclopediaPatcher
@@ -18,15 +19,17 @@
             Dictionary<string, PDAEncyclopedia.EntryData> mapping = PDAEncyclopedia.mapping;
 
             // Add custom entry data
-            foreach(KeyValuePair<string, PDAEncyclopedia.EntryData> entry in CustomEntryData)
+            foreach(KeyValuePair<string, PDAEncyclopedia.EntryData> customEntry in CustomEntryData)
             {
-                if(!mapping.ContainsKey(entry.Key))
+                if (!mapping.ContainsKey(customEntry.Key))
                 {
-                    mapping.Add(entry.Key, entry.Value);
+                    mapping.Add(customEntry.Key, customEntry.Value);
+                    Logger.Debug($"Adding PDAEncyclopedia EntryData for Key Value: {customEntry.Key}.");
                 }
                 else
                 {
-                    Logger.Warn($"PDAEncyclopedia already Contains EntryData for Key Value: {entry.Key}, Unable to Overwrite.");
+                    mapping[customEntry.Key] = customEntry.Value;
+                    Logger.Debug($"PDAEncyclopedia already Contains EntryData for Key Value: {customEntry.Key}, Overwriting Original.");
                 }
             }
         }


### PR DESCRIPTION
### Changes made in this pull request

  - Allow overwriting of scanner data and encyclopedia data.
  - Corrected multiple dictionary look ups.
  - Changed fragment count and fragment scan time to self checking dictionaries to log when things are duplicated.
