### PR TITLE
SMLHelper 2.9.0.1 HOTFIX: Revert default slider step

### DIFF
--- a/Example mod/mod.json
+++ b/Example mod/mod.json
@@ -2,10 +2,10 @@
   "Id": "SMLHelperExampleMod",
   "DisplayName": "Example Mod For SMLHelper",
   "Author": "The SMLHelper Dev Team",
-  "Version": "2.9",
+  "Version": "2.9.0.1",
   "Enable": true,
   "AssemblyName": "Example mod.dll",
   "VersionDependencies": {
-    "SMLHelper":  "2.9"
+    "SMLHelper":  "2.9.0.1"
   }
 }

--- a/SMLHelper/Options/SliderModOption.cs
+++ b/SMLHelper/Options/SliderModOption.cs
@@ -73,7 +73,7 @@
         /// <param name="value">The starting value.</param>
         protected void AddSliderOption(string id, string label, float minValue, float maxValue, float value)
         {
-            AddSliderOption(id, label, minValue, maxValue, value, null, null, 0.05f);
+            AddSliderOption(id, label, minValue, maxValue, value, null, null, 0);
         }
 
         /// <summary>
@@ -89,7 +89,7 @@
         /// (more on this <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings">here</see>)</param>
         protected void AddSliderOption(string id, string label, float minValue, float maxValue, float value, float? defaultValue, string valueFormat = null)
         {
-            AddSliderOption(id, label, minValue, maxValue, value, defaultValue, valueFormat, 0.05f);
+            AddSliderOption(id, label, minValue, maxValue, value, defaultValue, valueFormat, 0);
         }
 
         /// <summary>
@@ -104,7 +104,7 @@
         /// <param name="valueFormat"> format for value, e.g. "{0:F2}" or "{0:F0} %"
         /// (more on this <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings">here</see>)</param>
         /// <param name="step">Step for the slider, ie. round to nearest X</param>
-        protected void AddSliderOption(string id, string label, float minValue, float maxValue, float value, float? defaultValue, string valueFormat = null, float step = 0.05f)
+        protected void AddSliderOption(string id, string label, float minValue, float maxValue, float value, float? defaultValue, string valueFormat = null, float step = 0)
         {
             AddOption(new ModSliderOption(id, label, minValue, maxValue, value, defaultValue, valueFormat, step));
         }
@@ -138,9 +138,9 @@
 
         /// <summary>
         /// The step value of the <see cref="ModSliderOption"/>.
-        /// Defaults to 0.05f same as default code.
+        /// Defaults to 0f for compatibility with older mods.
         /// </summary>
-        public float Step { get; } = 0.05f;
+        public float Step { get; } = 0;
 
         /// <summary> Format for value field (<see cref="ModOptions.AddSliderOption(string, string, float, float, float, float?, string)"/>) </summary>
         public string ValueFormat { get; }
@@ -209,7 +209,7 @@
         /// <param name="defaultValue">The default value for the slider. If this is null then 'value' used as default.</param>
         /// <param name="valueFormat">Format for value field (<see cref="ModOptions.AddSliderOption(string, string, float, float, float, float?, string, float)"/>) </param>
         /// <param name="step">Step for the slider ie. round to nearest X</param>
-        internal ModSliderOption(string id, string label, float minValue, float maxValue, float value, float? defaultValue = null, string valueFormat = null, float step = 0.05f) : base(label, id)
+        internal ModSliderOption(string id, string label, float minValue, float maxValue, float value, float? defaultValue = null, string valueFormat = null, float step = 0) : base(label, id)
         {
             MinValue = minValue;
             MaxValue = maxValue;

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.9.0.0")]
-[assembly: AssemblyFileVersion("2.9.0.0")]
+[assembly: AssemblyVersion("2.9.0.1")]
+[assembly: AssemblyFileVersion("2.9.0.1")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.9",
+    "Version": "2.9.0.1",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll"

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.9",
+    "Version": "2.9.0.1",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll"


### PR DESCRIPTION
## Changes made in this version
Hotfix for an issue introduced in v2.9 where the new default slider step setting of `0.05f` is causing issues for some mods when they aren't specifying a step value. The new `SliderAttribute` usage is unaffected (still defaults to `0.05f` and this is well-documented).