### PR TITLE
Fix ConfigFile List Entry Duplication

### DIFF
--- a/SMLHelper/Utility/JsonUtils.cs
+++ b/SMLHelper/Utility/JsonUtils.cs
@@ -114,7 +114,8 @@
                 {
                     var jsonSerializerSettings = new JsonSerializerSettings()
                     {
-                        Converters = jsonConverters
+                        Converters = jsonConverters,
+                        ObjectCreationHandling = ObjectCreationHandling.Replace
                     };
 
                     string serializedJson = File.ReadAllText(path);


### PR DESCRIPTION
**TL;DR:** Fixes `List<>` entry duplication when reloading a JSON file by setting `ObjectCreationHandling` to `ObjectCreationHandling.Replace` in the `JsonSerializerSettings` object used when deserializing JSON data from disk. Perhaps we should consider adding an optional argument to the `Load` method to allow API consumers to customise this if they wish?

I'm open to discussion on how we want to approach this problem, so by all means, feel free to make suggestions. This PR is just my own take on it, and I likely haven't considered every angle.

---

ccgould brought this issue to my attention: they remarked that when storing a `List<>` collection in their `ConfigFile`, any time the `ConfigFile` was saved to disk, it was duplicating the entries of the list.

It turns out this was caused when they were manually calling `ConfigFile.Load`, so it was being loaded twice. On the second load, the entries in the `List<>` were being duplicated as by default, Newtonsoft.Json reuses existing objects. So, in memory, we have a list with entries A, B, and C, and on disk we have a serialized list with those same entries (A, B, C), and Newtonsoft.Json is reusing the existing `List<>` and adding the entries from disk to it during deserialization, causing the duplicate entries (A, B, C, A, B, C). The saving of the `ConfigFile` back to disk was not the cause, just what brought the issue to light.

So, by setting `ObjectCreationHandling` to `ObjectCreationHandling.Replace` in our `Load` method, rather than the default (`ObjectCreationHandling.Auto`: reuse existing objects, create new ones as needed), every time the JSON file is loaded from disk, we consider what is on disk to be the absolute source of truth, which is the expected behaviour.

You might think "But if they don't call `Load` manually" - which they shouldn't be doing if they're using the new `RegisterModOptions<ConfigFile>()` method as ccgould was - "that the issue will just go away so it doesn't need fixing" - but there are circumstances under which SMLHelper will automatically load the `ConfigFile` multiple times via the `LoadOn` property of the `MenuAttribute`, so it's not that simple and we need to consider how we want to handle this issue.

It is also possible to individually mark each member with a `JsonProperty` attribute and setting the `ObjectCreationHandling` property for that specific member, however setting the `ObjectCreationHandling` in the `JsonSerializerSettings` object used in this `Load` method will override that - meaning the only way to circumvent this behaviour is to load it yourself via Newtonsoft.Json directly. Perhaps therefore it might be wise to consider an option flag in the `Load` methods' signature?

We could also urge users of `List<>` in a `ConfigFile` to attribute that `List<>` with the `JsonProperty` attribute and set `ObjectCreationHandling` to `ObjectCreationHandling.Replace` for that specific member, rather than making `ObjectCreationHandling.Replace` the de facto standard in SMLHelper, however it is likely that many modders won't notice this issue before releasing a broken mod, and the fix requires them to reference Newtonsoft.Json, which currently uses different APIs across SN and BZ stable and experimental branches... so the less modders need to reference Newtonsoft.Json, the better IMO.

There is a workaround which doesn't require the modder to reference Newtonsoft.Json if they weren't already - if they use an `IEnumerable<>` or array instead of a `List<>`, Newtonsoft.Json seems to replace those by default since their API doesn't allow for adding new entries. This does however also mean that if the mod itself needs to add new entries to the array/`IEnumerable<>` at runtime, the modder will need to convert it to a `List<>` and back again or similar to achieve this.