### PR TITLE
SMLHelper 2.9.2 (Config List Load fix and BZ Stable fix Dynamic Language Patching)

### DIFF
--- a/SMLHelper/Assets/CustomFabricator.cs
+++ b/SMLHelper/Assets/CustomFabricator.cs
@@ -151,7 +151,7 @@
         /// <returns></returns>
         public override GameObject GetGameObject()
         {
-#if SUBNAUTICA_EXP || BELOWZERO_EXP
+#if SUBNAUTICA_EXP || BELOWZERO
             return null;
 #else
             GameObject prefab = this.Model switch

--- a/SMLHelper/Assets/Spawnable.cs
+++ b/SMLHelper/Assets/Spawnable.cs
@@ -4,10 +4,13 @@
     using SMLHelper.V2.Interfaces;
     using SMLHelper.V2.Utility;
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.IO;
     using System.Reflection;
+    using UnityEngine;
     using UWE;
+    using Logger = Logger;
 
     /// <summary>
     /// An item that can be spawned into the game.
@@ -98,9 +101,13 @@
             CorePatchEvents += () =>
             {
                 PrefabHandler.RegisterPrefab(this);
-                SpriteHandler.RegisterSprite(TechType, GetItemSprite());
 
-                if(!SizeInInventory.Equals(defaultSize))
+#if SN1
+                SpriteHandler.RegisterSprite(TechType, GetItemSprite());
+#elif BELOWZERO
+                CoroutineHost.StartCoroutine(RegisterSpriteAsync());
+#endif
+                if (!SizeInInventory.Equals(defaultSize))
                 {
                     CraftDataHandler.SetItemSize(TechType, SizeInInventory);
                 }
@@ -115,6 +122,17 @@
                 }
             };
         }
+
+#if BELOWZERO
+        private IEnumerator RegisterSpriteAsync()
+        {
+            while (!SpriteManager.hasInitialized)
+                yield return new WaitForSecondsRealtime(1);
+
+            SpriteHandler.RegisterSprite(TechType, GetItemSprite());
+            yield break;
+        }
+#endif
 
         /// <summary>
         /// This event triggers <c>before</c> the core patching methods begins.

--- a/SMLHelper/Assets/Spawnable.cs
+++ b/SMLHelper/Assets/Spawnable.cs
@@ -102,7 +102,7 @@
             {
                 PrefabHandler.RegisterPrefab(this);
 
-#if SN1
+#if SUBNAUTICA
                 SpriteHandler.RegisterSprite(TechType, GetItemSprite());
 #elif BELOWZERO
                 CoroutineHost.StartCoroutine(RegisterSpriteAsync());

--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -34,6 +34,8 @@
             TechTypePatcher.cacheManager.LoadCache();
             Logger.Debug("Loading CraftTreeType Cache");
             CraftTreeTypePatcher.cacheManager.LoadCache();
+            Logger.Debug("Loading PingType Cache");
+            PingTypePatcher.cacheManager.LoadCache();
 
             PrefabDatabasePatcher.PrePatch(harmony);
         }
@@ -79,6 +81,9 @@
             TechTypePatcher.cacheManager.SaveCache();
             Logger.Debug("Saving CraftTreeType Cache");
             CraftTreeTypePatcher.cacheManager.SaveCache();
+            Logger.Debug("Saving PingType Cache");
+            PingTypePatcher.cacheManager.SaveCache();
+
         }
     }
 }

--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -60,7 +60,7 @@
             ConsoleCommandsPatcher.Patch(harmony);
             LanguagePatcher.Patch(harmony);
             PrefabDatabasePatcher.PostPatch(harmony);
-            SpritePatcher.Patch();
+            SpritePatcher.Patch(harmony);
             KnownTechPatcher.Patch(harmony);
             BioReactorPatcher.Patch();
             OptionsPanelPatcher.Patch(harmony);

--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -48,6 +48,9 @@
             FishPatcher.Patch(harmony);
 
             TechTypePatcher.Patch();
+#if BELOWZERO
+            ButtonPatcher.Patch();
+#endif
             CraftTreeTypePatcher.Patch();
             PingTypePatcher.Patch();
             EnumPatcher.Patch(harmony);

--- a/SMLHelper/Options/ChoiceModOption.cs
+++ b/SMLHelper/Options/ChoiceModOption.cs
@@ -101,6 +101,9 @@
         protected void AddChoiceOption(string id, string label, string[] options, string value)
         {
             int index = Array.IndexOf(options, value);
+            if (index < 0)
+                index = 0;
+
             AddChoiceOption(id, label, options, index);
         }
         /// <summary>

--- a/SMLHelper/Options/KeybindModOption.cs
+++ b/SMLHelper/Options/KeybindModOption.cs
@@ -10,6 +10,7 @@
     using Text = UnityEngine.UI.Text;
 #elif BELOWZERO
     using Text = TMPro.TextMeshProUGUI;
+    using SMLHelper.V2.Patchers.EnumPatching;
 #endif
 
     /// <summary>
@@ -139,9 +140,16 @@
             // Update bindings
             binding.device = Device;
             binding.value = KeyCodeUtils.KeyCodeToString(Key);
+#if SUBNAUTICA
             binding.onValueChanged.RemoveAllListeners();
             var callback = new UnityAction<KeyCode>((KeyCode key) => parentOptions.OnKeybindChange(Id, key));
             binding.onValueChanged.AddListener(new UnityAction<string>((string s) => callback?.Invoke(KeyCodeUtils.StringToKeyCode(s))));
+#elif BELOWZERO
+            binding.action = ButtonPatcher.EnsureButton(Label, KeyCodeUtils.KeyCodeToString(Key), Device);
+            binding.bindingSet = GameInput.BindingSet.Primary;
+            var callback = new UnityAction<KeyCode>((KeyCode key) => parentOptions.OnKeybindChange(Id, key));
+            binding.bindCallback = new Action<GameInput.Device, GameInput.Button, GameInput.BindingSet, string>((GameInput.Device device, GameInput.Button button, GameInput.BindingSet bindingSet, string s) => { callback?.Invoke(KeyCodeUtils.StringToKeyCode(s)); panel.TryBind1_0(device, button, bindingSet, s); binding.RefreshValue(); });
+#endif
 
             base.AddToPanel(panel, tabIndex);
         }

--- a/SMLHelper/Options/ModOptionTooltip.cs
+++ b/SMLHelper/Options/ModOptionTooltip.cs
@@ -11,6 +11,8 @@
         void Awake() => Destroy(GetComponent<LayoutElement>());
 
 #if BELOWZERO
+        public bool showTooltipOnDrag => true;
+
         public void GetTooltip(TooltipData tooltip)
         {
             tooltip.prefix.Append(Tooltip);

--- a/SMLHelper/Patchers/EnumPatching/ButtonPatcher.cs
+++ b/SMLHelper/Patchers/EnumPatching/ButtonPatcher.cs
@@ -1,0 +1,86 @@
+﻿#if BELOWZERO
+namespace SMLHelper.V2.Patchers.EnumPatching
+{
+    using System;
+    using System.Collections.Generic;
+    using SMLHelper.V2.Handlers;
+    using Utility;
+    using static GameInput;
+
+    internal class ButtonPatcher
+    {
+        private const string ButtonEnumName = "Button";
+        internal static readonly int startingIndex = 1000;
+        internal static readonly List<int> bannedIndices = new List<int>();
+        internal static readonly List<Tuple<Device, Button, string>> RegisteredButtons = new List<Tuple<Device, Button, string>>();
+
+        internal static readonly EnumCacheManager<Button> cacheManager =
+            new EnumCacheManager<Button>(
+                enumTypeName: ButtonEnumName,
+                startingIndex: startingIndex,
+                bannedIDs: ExtBannedIdManager.GetBannedIdsFor(ButtonEnumName, bannedIndices));
+
+        internal static Button EnsureButton(string name, string key, Device device)
+        {
+            if(!cacheManager.TryParse(name, out Button button))
+            {
+                EnumTypeCache cache = cacheManager.RequestCacheForTypeName(name);
+
+                if (cache == null)
+                {
+                    cache = new EnumTypeCache()
+                    {
+                        Name = name,
+                        Index = cacheManager.GetNextAvailableIndex()
+                    };
+                }
+
+                if (cacheManager.IsIndexAvailable(cache.Index))
+                    cache.Index = cacheManager.GetNextAvailableIndex();
+
+                button = (Button)cache.Index;
+                cacheManager.Add(button, cache.Index, cache.Name);
+                RegisterNewButton(name, key, button, device);
+
+                Logger.Log($"Successfully added Button: '{name}' to Index: '{cache.Index}'", LogLevel.Debug);
+                return button;
+            }
+            else
+            {
+                return button;
+            }
+        }
+
+        private static void RegisterNewButton(string name, string key, Button button, Device device)
+        {
+            var bind = new Tuple<Device, Button, string>(device, button, key);
+            if (RegisteredButtons.Contains(bind))
+                return;
+
+            RegisteredButtons.Add(bind);
+            LanguageHandler.SetLanguageLine($"Option{name}", name);
+            Language.main.LoadLanguageFile(Language.main.GetCurrentLanguage());
+            GameInput.AddKeyInput(name, KeyCodeUtils.StringToKeyCode(key), device);
+            GameInput.instance.Initialize();
+            for (int i = 0; i < GameInput.numDevices; i++)
+            {
+                GameInput.SetupDefaultBindings((GameInput.Device)i);
+            }
+            foreach(Tuple<Device, Button, string> binding in RegisteredButtons)
+            {
+                GameInput.SafeSetBinding(binding.Item1, binding.Item2, BindingSet.Primary, binding.Item3);
+            }
+
+        }
+
+        internal static void Patch()
+        {
+            IngameMenuHandler.Main.RegisterOneTimeUseOnSaveEvent(() => cacheManager.SaveCache());
+
+            Logger.Log($"Added {cacheManager.ModdedKeysCount} Buttons succesfully into the game.", LogLevel.Info);
+
+            Logger.Log("ButtonPatcher is done.", LogLevel.Debug);
+        }
+    }
+}
+#endif

--- a/SMLHelper/Patchers/EnumPatching/EnumPatcher.cs
+++ b/SMLHelper/Patchers/EnumPatching/EnumPatcher.cs
@@ -30,6 +30,12 @@
             {
                 __result = GetValues(PingTypePatcher.cacheManager, __result);
             }
+#if BELOWZERO
+            else if (enumType == typeof(GameInput.Button))
+            {
+                __result = GetValues(ButtonPatcher.cacheManager, __result);
+            }
+#endif
         }
 
         private static T[] GetValues<T>(EnumCacheManager<T> cacheManager, Array __result) where T : Enum
@@ -50,7 +56,11 @@
         {
             if (IsDefined(TechTypePatcher.cacheManager, enumType, value) ||
                 IsDefined(CraftTreeTypePatcher.cacheManager, enumType, value) ||
-                IsDefined(PingTypePatcher.cacheManager, enumType, value))
+                IsDefined(PingTypePatcher.cacheManager, enumType, value)
+#if BELOWZERO
+                || IsDefined(ButtonPatcher.cacheManager, enumType, value)
+#endif
+                )
             {
                 __result = true;
                 return false;
@@ -83,7 +93,13 @@
                 __result = pingType;
                 return false;
             }
-
+#if BELOWZERO
+            else if (enumType == typeof(GameInput.Button) && ButtonPatcher.cacheManager.TryParse(value, out GameInput.Button button))
+            {
+                __result = button;
+                return false;
+            }
+#endif
             return true;
         }
 
@@ -105,6 +121,11 @@
                     __result = pingTypeName;
                     return false;
 
+#if BELOWZERO
+                case GameInput.Button button when ButtonPatcher.cacheManager.TryGetValue(button, out var buttonName):
+                    __result = buttonName;
+                    return false;
+#endif
                 default:
                     return true;
             }

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -20,7 +20,7 @@
 
         internal static void RepatchCheck(ref Language __instance, string key)
         {
-            if (string.IsNullOrEmpty(key) || !customLines.TryGetValue(key, out _))
+            if (string.IsNullOrEmpty(key) || !customLines.ContainsKey(key))
                 return;
 
             if (!__instance.strings.TryGetValue(key, out _))

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -23,7 +23,7 @@
             if (string.IsNullOrEmpty(key) || !customLines.ContainsKey(key))
                 return;
 
-            if (!__instance.strings.TryGetValue(key, out _))
+            if (!__instance.strings.ContainsKey(key))
                 InsertCustomLines(ref __instance);
         }
 

--- a/SMLHelper/Patchers/SpritePatcher.cs
+++ b/SMLHelper/Patchers/SpritePatcher.cs
@@ -33,7 +33,7 @@
 
         internal static void Patch(Harmony harmony)
         {
-#if SN1
+#if SUBNAUTICA
             PatchSprites();
 #elif BELOWZERO
             CoroutineHost.StartCoroutine(PatchSpritesAsync());

--- a/SMLHelper/Patchers/SpritePatcher.cs
+++ b/SMLHelper/Patchers/SpritePatcher.cs
@@ -19,7 +19,7 @@
 
         internal static void PatchCheck(SpriteManager.Group group, string name)
         {
-            if (string.IsNullOrEmpty(name) || !ModSprite.ModSprites.ContainsKey(group) || !ModSprite.ModSprites[group].TryGetValue(name, out _))
+            if (string.IsNullOrEmpty(name) || !ModSprite.ModSprites.TryGetValue(group, out var groupDict) || !groupDict.TryGetValue(name, out _))
                 return;
 #if BELOWZERO
             if (!SpriteManager.hasInitialized)

--- a/SMLHelper/Patchers/SpritePatcher.cs
+++ b/SMLHelper/Patchers/SpritePatcher.cs
@@ -21,7 +21,7 @@
 
         private static IEnumerator PatchSpritesAsync()
         {
-#if BZ
+#if BELOWZERO
             while(SpriteManager.atlases is null)
             {
                 yield return new WaitForSecondsRealtime(1);

--- a/SMLHelper/Patchers/SpritePatcher.cs
+++ b/SMLHelper/Patchers/SpritePatcher.cs
@@ -21,11 +21,12 @@
 
         private static IEnumerator PatchSpritesAsync()
         {
+#if BZ
             while(SpriteManager.atlases is null)
             {
                 yield return new WaitForSecondsRealtime(1);
             }
-
+#endif
             foreach (var moddedSpriteGroup in ModSprite.ModSprites)
             {
                 SpriteManager.Group moddedGroup = moddedSpriteGroup.Key;
@@ -51,6 +52,7 @@
             }
 
             Logger.Debug("SpritePatcher is done.");
+            yield break;
         }
 
         private static Dictionary<string, Sprite> GetSpriteAtlas(SpriteManager.Group groupKey)

--- a/SMLHelper/Patchers/SpritePatcher.cs
+++ b/SMLHelper/Patchers/SpritePatcher.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Reflection;
     using Assets;
     using HarmonyLib;
     using UnityEngine;
@@ -35,11 +36,13 @@
         {
 #if SUBNAUTICA
             PatchSprites();
+            MethodInfo methodInfo = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.Get), new Type[] { typeof(SpriteManager.Group), typeof(string) });
 #elif BELOWZERO
             CoroutineHost.StartCoroutine(PatchSpritesAsync());
+            MethodInfo methodInfo = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.Get), new Type[] { typeof(SpriteManager.Group), typeof(string), typeof(Sprite) });
 #endif
             HarmonyMethod patchCheck = new HarmonyMethod(AccessTools.Method(typeof(SpritePatcher), nameof(SpritePatcher.PatchCheck)));
-            harmony.Patch(AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.Get), new Type[] { typeof(SpriteManager.Group), typeof(string), typeof(Sprite) }), prefix: patchCheck);
+            harmony.Patch(methodInfo, prefix: patchCheck);
         }
 
 #if BELOWZERO

--- a/SMLHelper/Patchers/SpritePatcher.cs
+++ b/SMLHelper/Patchers/SpritePatcher.cs
@@ -1,7 +1,11 @@
 ﻿namespace SMLHelper.V2.Patchers
 {
+    using System.Collections;
     using System.Collections.Generic;
     using Assets;
+    using UnityEngine;
+    using UWE;
+    using Logger = Logger;
 #if SUBNAUTICA
     using Sprite = Atlas.Sprite;
 #elif BELOWZERO
@@ -12,6 +16,16 @@
     {
         internal static void Patch()
         {
+            CoroutineHost.StartCoroutine(PatchSpritesAsync());
+        }
+
+        private static IEnumerator PatchSpritesAsync()
+        {
+            while(SpriteManager.atlases is null)
+            {
+                yield return new WaitForSecondsRealtime(1);
+            }
+
             foreach (var moddedSpriteGroup in ModSprite.ModSprites)
             {
                 SpriteManager.Group moddedGroup = moddedSpriteGroup.Key;

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.9.1.1")]
-[assembly: AssemblyFileVersion("2.9.1.1")]
+[assembly: AssemblyVersion("2.9.2.0")]
+[assembly: AssemblyFileVersion("2.9.2.0")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -224,6 +224,7 @@
     <Compile Include="Patchers\CraftDataPatcher_BelowZero.cs" />
     <Compile Include="Patchers\CraftDataPatcher_Subnautica.cs" />
     <Compile Include="Patchers\CraftTreePatcher.cs" />
+    <Compile Include="Patchers\EnumPatching\ButtonPatcher.cs" />
     <Compile Include="Patchers\EnumPatching\CraftTreeTypePatcher.cs" />
     <Compile Include="Patchers\EnumPatching\EnumPatcher.cs" />
     <Compile Include="Patchers\FishPatcher.cs" />

--- a/SMLHelper/Utility/JsonUtils.cs
+++ b/SMLHelper/Utility/JsonUtils.cs
@@ -114,7 +114,8 @@
                 {
                     var jsonSerializerSettings = new JsonSerializerSettings()
                     {
-                        Converters = jsonConverters
+                        Converters = jsonConverters,
+                        ObjectCreationHandling = ObjectCreationHandling.Replace
                     };
 
                     string serializedJson = File.ReadAllText(path);

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.9.1.1",
+    "Version": "2.9.2",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll"

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.9.1.1",
+    "Version": "2.9.2",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll"


### PR DESCRIPTION
### Changes made in this pull request

  - Both Games  Fix ConfigFile List Entry Duplication #194
  - BZ fix for new Tooltip Property breaking mod menu.
  - BZ Moved changes from Experimental branch to Stable branch for CraftData Async changes.
  - BZ Fix for Mod Options Keybindings.
  - Make the SpritePatcher wait for the Sprite Atlas to be loaded before patching.
  - More Dynamic Language Patching
  - Semi Dynamic SpritePatcher
  - BZ GetItemSprite() Fix for ModPrefabs Using the Assets system. 
  - Prevent unknown JSON string from BREAKING Choice options #197 

