### PR TITLE
CraftDataHandler_BelowZero Fixes, Additions and 1 Removal

### DIFF
--- a/SMLHelper/Handlers/CraftDataHandler.cs
+++ b/SMLHelper/Handlers/CraftDataHandler.cs
@@ -41,7 +41,7 @@
 #elif BELOWZERO
         /// <summary>
         /// <para>Allows you to edit QuickSlotType for TechTypes. Can be used for existing TechTypes too.</para>
-        /// <para>Careful: This has to be called after <see cref="SetTechData(TechType, Crafting.RecipeData)"/> and <see cref="SetTechData(TechType, JsonValue)"/>.</para>
+        /// <para>Careful: This has to be called after <see cref="SetTechData(TechType, Crafting.RecipeData)"/>.</para>
         /// </summary>
         /// <param name="techType">The TechType whose QuickSlotType you want to edit.</param>
         /// <param name="slotType">The QuickSlotType for that TechType.</param>

--- a/SMLHelper/Interfaces/ICraftDataHandler.cs
+++ b/SMLHelper/Interfaces/ICraftDataHandler.cs
@@ -16,14 +16,14 @@
 #if SUBNAUTICA
         /// <summary>
         /// <para>Allows you to edit QuickSlotType for TechTypes. Can be used for existing TechTypes too.</para>
-        /// <para>Careful: This has to be called after <see cref="SetTechData(TechType, Crafting.TechData)"/> and <see cref="SetTechData(TechType, Crafting.TechData)"/>.</para>
+        /// <para>Careful: This has to be called after <see cref="SetTechData(TechType, Crafting.TechData)"/> and <see cref="SetTechData(TechType, ITechData)"/>.</para>
         /// </summary>
         /// <param name="techType">The TechType whose QuickSlotType you want to edit.</param>
         /// <param name="slotType">The QuickSlotType for that TechType.</param>
 #elif BELOWZERO
         /// <summary>
         /// <para>Allows you to edit QuickSlotType for TechTypes. Can be used for existing TechTypes too.</para>
-        /// <para>Careful: This has to be called after <see cref="SetTechData(TechType, Crafting.RecipeData)"/> and <see cref="SetTechData(TechType, JsonValue)"/>.</para>
+        /// <para>Careful: This has to be called after <see cref="SetTechData(TechType, Crafting.RecipeData)"/>.</para>
         /// </summary>
         /// <param name="techType">The TechType whose QuickSlotType you want to edit.</param>
         /// <param name="slotType">The QuickSlotType for that TechType.</param>

--- a/SMLHelper/Interfaces/ICraftDataHandler_BelowZero.cs
+++ b/SMLHelper/Interfaces/ICraftDataHandler_BelowZero.cs
@@ -16,21 +16,12 @@ namespace SMLHelper.V2.Interfaces
         void SetTechData(TechType techType, RecipeData techData);
 
         /// <summary>
-        /// <para>Allows you to edit JsonValues Directly for TechTypes.</para>
-        /// <para>Can be used for existing TechTypes too.</para>
-        /// </summary>
-        /// <param name="techType">The TechType whose TechData you want to edit.</param>
-        /// <param name="jsonValue">The JsonValue for that TechType.</param>
-        /// <seealso cref="TechData.defaults"/>
-        void SetTechData(TechType techType, JsonValue jsonValue);
-
-        /// <summary>
         /// Safely accesses the crafting data from a modded item.<para/>
         /// WARNING: This method is highly dependent on mod load order. 
         /// Make sure your mod is loading after the mod whose TechData you are trying to access.
         /// </summary>
         /// <param name="techType">The TechType whose TechData you want to access.</param>
-        /// <returns>The JsonValue from the modded item if it exists; Otherwise, returns <c>null</c>.</returns>
+        /// <returns>The RecipeData from the modded item if it exists; Otherwise, returns <c>null</c>.</returns>
         RecipeData GetRecipeData(TechType techType);
 
         /// <summary>
@@ -39,25 +30,52 @@ namespace SMLHelper.V2.Interfaces
         /// Make sure your mod is loading after the mod whose TechData you are trying to access.
         /// </summary>
         /// <param name="techType">The TechType whose TechData you want to access.</param>
-        /// <returns>The JsonValue from the modded item if it exists; Otherwise, returns <c>null</c>.</returns>
+        /// <returns>The RecipeData from the modded item if it exists; Otherwise, returns <c>null</c>.</returns>
+        RecipeData GetTechData(TechType techType);
+
+        /// <summary>
+        /// Safely accesses the crafting data from a modded item.<para/>
+        /// WARNING: This method is highly dependent on mod load order. 
+        /// Make sure your mod is loading after the mod whose TechData you are trying to access.
+        /// </summary>
+        /// <param name="techType">The TechType whose TechData you want to access.</param>
+        /// <returns>The RecipeData from the modded item if it exists; Otherwise, returns <c>null</c>.</returns>
         RecipeData GetModdedRecipeData(TechType techType);
 
         /// <summary>
-        /// <para>Allows you to add ingredients for a TechType crafting recipe.</para>
+        /// Safely accesses the crafting data from a modded item.<para/>
+        /// WARNING: This method is highly dependent on mod load order. 
+        /// Make sure your mod is loading after the mod whose TechData you are trying to access.
+        /// </summary>
+        /// <param name="techType">The TechType whose TechData you want to access.</param>
+        /// <returns>The RecipeData from the modded item if it exists; Otherwise, returns <c>null</c>.</returns>
+        RecipeData GetModdedTechData(TechType techType);
+
+        /// <summary>
+        /// <para>Allows you to set ingredients for a TechType crafting recipe.</para>
         /// <para>Can be used for existing TechTypes too.</para>
         /// </summary>
         /// <param name="techType">The TechType whose ingredient list you want to edit.</param>
         /// <param name="ingredients">The collection of Ingredients for that TechType.</param>
         /// <seealso cref="Ingredient"/>
-        void AddIngredients(TechType techType, ICollection<Ingredient> ingredients);
+        void SetIngredients(TechType techType, ICollection<Ingredient> ingredients);
 
         /// <summary>
-        /// <para>Allows you to add linked items for a TechType crafting recipe.</para>
+        /// <para>Allows you to set linked items for a TechType crafting recipe.</para>
         /// <para>Can be used for existing TechTypes too.</para>
         /// </summary>
         /// <param name="techType">The TechType whose ingredient list you want to edit.</param>
         /// <param name="linkedItems">The collection of linked items for that TechType</param>
-        void AddLinkedItems(TechType techType, ICollection<TechType> linkedItems);
+        void SetLinkedItems(TechType techType, ICollection<TechType> linkedItems);
+
+
+        /// <summary>
+        /// <para>Allows you to edit the Cold Resistance for TechTypes.</para>
+        /// <para>Can be used for existing TechTypes too.</para>
+        /// </summary>
+        /// <param name="techType">The TechType whose Cold Resistance you want to edit.</param>
+        /// <param name="resistance">The int value for the Cold Resistance.</param>
+        void SetColdResistance(TechType techType, int resistance);
     }
 }
 #endif

--- a/SMLHelper/Patchers/CraftDataPatcher_BelowZero.cs
+++ b/SMLHelper/Patchers/CraftDataPatcher_BelowZero.cs
@@ -8,7 +8,7 @@ namespace SMLHelper.V2.Patchers
 
     internal partial class CraftDataPatcher
     {
-        internal static IDictionary<TechType, JsonValue> CustomTechData = new SelfCheckingDictionary<TechType, JsonValue>("CustomTechData", AsStringFunction);
+        internal static readonly IDictionary<TechType, JsonValue> CustomTechData = new SelfCheckingDictionary<TechType, JsonValue>("CustomTechData", AsStringFunction);
 
         private static void PatchForBelowZero(Harmony harmony)
         {
@@ -62,8 +62,6 @@ namespace SMLHelper.V2.Patchers
                 TechType updatedTechData = updated[i];
                 CustomTechData[updatedTechData] = TechData.entries[updatedTechData];
             }
-
-            CustomTechData.Clear();
 
             if (added.Count > 0)
             {


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed Values overwriting ALL values when setting them instead of just the values that were changed.
  - Added Handler for Cold Resist
  - Added Dummy GetTechData and GetModdedTechData so mods can use the same across both games more easily.
  - Remove SetTechData that used direct JsonValue as if anyone used it, it would OVERWRITE everything instead of just the few things the person was trying to change.
