### PR TITLE
Multiple Fixes for Loot Dist system

### DIFF
--- a/SMLHelper/Assets/ModPrefabCache.cs
+++ b/SMLHelper/Assets/ModPrefabCache.cs
@@ -12,7 +12,7 @@
     /// </summary>
     public static class ModPrefabCache
     {
-        private const float cleanDelay = 1.0f; // delay in secs before attempt to remove prefab from cache
+        private const float cleanDelay = 30.0f; // delay in secs before attempt to remove prefab from cache
 
         // list of prefabs for removing (Item1 - time of addition, Item2 - prefab gameobject)
         private readonly static List<Tuple<float, GameObject>> prefabs = new List<Tuple<float, GameObject>>();

--- a/SMLHelper/Handlers/LootDistributionHandler.cs
+++ b/SMLHelper/Handlers/LootDistributionHandler.cs
@@ -164,7 +164,10 @@
 
         void ILootDistributionHandler.AddLootDistributionData(string classId, LootDistributionData.SrcData data)
         {
-            LootDistributionPatcher.CustomSrcData.Add(classId, data);
+            if (LootDistributionPatcher.CustomSrcData.ContainsKey(classId))
+                Logger.Log($"{classId}-{data.prefabPath} already has custom distribution data. Replacing with latest.", LogLevel.Debug);
+
+            LootDistributionPatcher.CustomSrcData[classId] = data;
         }
 
         void ILootDistributionHandler.EditLootDistributionData(string classId, BiomeType biome, float probability, int count)

--- a/SMLHelper/Handlers/PDAEncyclopediaHandler.cs
+++ b/SMLHelper/Handlers/PDAEncyclopediaHandler.cs
@@ -20,6 +20,9 @@
 
         void IPDAEncyclopediaHandler.AddCustomEntry(PDAEncyclopedia.EntryData entry)
         {
+            if (PDAEncyclopediaPatcher.CustomEntryData.ContainsKey(entry.key))
+                Logger.Log($"{entry.key} already has custom PDAEncyclopedia.EntryData. Replacing with latest.", LogLevel.Debug);
+
             PDAEncyclopediaPatcher.CustomEntryData[entry.key] = entry;
         }
         

--- a/SMLHelper/Handlers/PDAHandler.cs
+++ b/SMLHelper/Handlers/PDAHandler.cs
@@ -54,6 +54,9 @@
         /// <param name="entryData">The <see cref="PDAScanner.EntryData"/> of the entry. Must be populated when passed in.</param>
         void IPDAHandler.AddCustomScannerEntry(PDAScanner.EntryData entryData)
         {
+            if (PDAPatcher.CustomEntryData.ContainsKey(entryData.key))
+                Logger.Log($"{entryData.key} already has custom PDAScanner.EntryData. Replacing with latest.", LogLevel.Debug);
+
             PDAPatcher.CustomEntryData[entryData.key] = entryData;
         }
 

--- a/SMLHelper/Handlers/WorldEntityDatabaseHandler.cs
+++ b/SMLHelper/Handlers/WorldEntityDatabaseHandler.cs
@@ -54,7 +54,10 @@
 
         void IWorldEntityDatabaseHandler.AddCustomInfo(string classId, WorldEntityInfo data)
         {
-            WorldEntityDatabasePatcher.CustomWorldEntityInfos.Add(classId, data);
+            if(WorldEntityDatabasePatcher.CustomWorldEntityInfos.ContainsKey(classId))
+                V2.Logger.Log($"{classId}-{data.techType} already has custom WorldEntityInfo. Replacing with latest.", LogLevel.Debug);
+
+            WorldEntityDatabasePatcher.CustomWorldEntityInfos[classId] = data;
         }
     }
 }


### PR DESCRIPTION
### Changes made in this pull request

  - Instead of deleting both bits of data and neither working this will overwrite with the latest loaded
  - log overwrites when in debug mode
  - increased how long until a prefab in the cache is deleted to 30s as cached prefabs were getting deleted before the delayed spawn system could spawn them.
 - Added Patch to fix Mod Prefab lootdist spawning in SN1.EXP and Both BZ