### PR TITLE
TechTypeHandler now gets the mod's name by passing the Assembly instead of a string

### DIFF
--- a/SMLHelper/Assets/ModPrefab.cs
+++ b/SMLHelper/Assets/ModPrefab.cs
@@ -1,4 +1,6 @@
-﻿namespace SMLHelper.V2.Assets
+﻿using System.Reflection;
+
+namespace SMLHelper.V2.Assets
 {
     using System;
     using System.Collections;
@@ -44,7 +46,7 @@
             return ClassIdDictionary.TryGetValue(classId, out prefab);
         }
 
-        internal readonly string ModName;
+        internal readonly Assembly Mod;
 
         /// <summary>
         /// The class identifier used for the <see cref="PrefabIdentifier" /> component whenever applicable.
@@ -76,7 +78,7 @@
             this.PrefabFileName = prefabFileName;
             this.TechType = techType;
 
-            ModName = GetType().Assembly.GetName().Name;
+            Mod = GetType().Assembly;
         }
 
         internal GameObject GetGameObjectInternal()

--- a/SMLHelper/Assets/PdaItem.cs
+++ b/SMLHelper/Assets/PdaItem.cs
@@ -149,7 +149,7 @@
 
         internal sealed override void PatchTechType()
         {
-            TechType = TechTypeHandler.AddTechType(ModName, ClassID, FriendlyName, Description, UnlockedAtStart);
+            TechType = TechTypeHandler.AddTechType(Mod, ClassID, FriendlyName, Description, UnlockedAtStart);
         }
     }
 }

--- a/SMLHelper/Assets/Spawnable.cs
+++ b/SMLHelper/Assets/Spawnable.cs
@@ -182,7 +182,7 @@
 
         internal virtual void PatchTechType()
         {
-            TechType = TechTypeHandler.AddTechType(ModName, ClassID, FriendlyName, Description, false);
+            TechType = TechTypeHandler.AddTechType(Mod, ClassID, FriendlyName, Description, false);
         }
 
 #if SUBNAUTICA

--- a/SMLHelper/Handlers/TechTypeHandler.cs
+++ b/SMLHelper/Handlers/TechTypeHandler.cs
@@ -28,20 +28,20 @@
             // Hide constructor
         }
 
-        TechType ITechTypeHandlerInternal.AddTechType(Assembly assembly, string internalName, string displayName, string tooltip)
+        TechType ITechTypeHandlerInternal.AddTechType(Assembly modAssembly, string internalName, string displayName, string tooltip)
         {
-            return Singleton.AddTechType(assembly, internalName, displayName, tooltip, true);
+            return Singleton.AddTechType(modAssembly, internalName, displayName, tooltip, true);
         }
 
-        TechType ITechTypeHandlerInternal.AddTechType(Assembly assembly, string internalName, string displayName, string tooltip, bool unlockAtStart)
+        TechType ITechTypeHandlerInternal.AddTechType(Assembly modAssembly, string internalName, string displayName, string tooltip, bool unlockAtStart)
         {
-            string modName = assembly.GetName().Name;
+            string modName = modAssembly.GetName().Name;
             
             // Register the TechType.
             var techType = TechTypePatcher.AddTechType(internalName);
             
             // Remember which Assembly added it
-            TechTypesAddedBy[techType] = assembly;
+            TechTypesAddedBy[techType] = modAssembly;
             
             // register Language Lines.
             LanguagePatcher.AddCustomLanguageLine(modName, internalName, displayName);

--- a/SMLHelper/Handlers/TechTypeHandler.cs
+++ b/SMLHelper/Handlers/TechTypeHandler.cs
@@ -101,7 +101,7 @@
         /// <param name="internalName">The internal name of the TechType. Should not contain special characters.</param>
         /// <param name="displayName">The display name of the TechType. Can be anything.</param>
         /// <param name="tooltip">The tooltip, displayed when hovered in an inventory. Can be anything.</param>
-        /// <param name="unlockAtStart">Whether this TechType should be unlocked on game start, or not. By default, <c>true</c>.</param>
+        /// <param name="unlockAtStart">Whether this TechType should be unlocked on game start, or not. By default, <see langword="true"/>.</param>
         /// <returns>The new <see cref="TechType"/> that is created.</returns>
         public static TechType AddTechType(string internalName, string displayName, string tooltip, bool unlockAtStart)
         {
@@ -128,7 +128,7 @@
         /// <param name="displayName">The display name of the TechType. Can be anything.</param>
         /// <param name="tooltip">The tooltip, displayed when hovered in an inventory. Can be anything.</param>
         /// <param name="sprite">The sprite that will related to this TechType.</param>
-        /// <param name="unlockAtStart">Whether this TechType should be unlocked on game start, or not. By default, <c>true</c>.</param>
+        /// <param name="unlockAtStart">Whether this TechType should be unlocked on game start, or not. By default, <see langword="true"/>.</param>
         /// <returns>The new <see cref="TechType"/> that is created.</returns>
         public static TechType AddTechType(string internalName, string displayName, string tooltip, Atlas.Sprite sprite, bool unlockAtStart)
         {
@@ -155,7 +155,7 @@
         /// <param name="displayName">The display name of the TechType. Can be anything.</param>
         /// <param name="tooltip">The tooltip, displayed when hovered in an inventory. Can be anything.</param>
         /// <param name="sprite">The sprite that will related to this TechType.</param>
-        /// <param name="unlockAtStart">Whether this TechType should be unlocked on game start, or not. By default, <c>true</c>.</param>
+        /// <param name="unlockAtStart">Whether this TechType should be unlocked on game start, or not. By default, <see langword="true"/>.</param>
         /// <returns>The new <see cref="TechType"/> that is created.</returns>
         public static TechType AddTechType(string internalName, string displayName, string tooltip, Sprite sprite, bool unlockAtStart)
         {
@@ -168,7 +168,7 @@
         /// <param name="techtypeString">The string used to define the modded item's new techtype.</param>
         /// <param name="modTechType">The TechType enum value of the modded. Defaults to <see cref="TechType.None" /> when the item was not found.</param>
         /// <returns>
-        ///   <c>True</c> if the item was found; Otherwise <c>false</c>.
+        ///   <see langword="true"/> if the item was found; Otherwise <see langword="false"/>.
         /// </returns>
         /// <remarks>
         /// There's no guarantee in which order SMLHelper dependent mods are loaded,
@@ -183,9 +183,9 @@
         /// <summary>
         /// Safely looks for a modded item from another mod in the SMLHelper TechTypeCache.
         /// </summary>
-        /// <param name="techtypeString">The string used to define the modded item's new techtype.</param>
+        /// <param name="techtypeString">The string used to define the modded item's new <see cref="TechType"/>.</param>
         /// <returns>
-        ///   <c>True</c> if the item was found; Otherwise <c>false</c>.
+        ///   <c>True</c> if the item was found; Otherwise <see langword="false"/>.
         /// </returns>
         /// <remarks>
         /// There's no guarantee in which order SMLHelper dependent mods are loaded,
@@ -206,7 +206,7 @@
         /// <param name="internalName">The internal name of the TechType. Should not contain special characters.</param>
         /// <param name="displayName">The display name of the TechType. Can be anything.</param>
         /// <param name="tooltip">The tooltip, displayed when hovered in an inventory. Can be anything.</param>
-        /// <param name="unlockAtStart">Whether this TechType should be unlocked on game start, or not. By default, <c>true</c>.</param>
+        /// <param name="unlockAtStart">Whether this TechType should be unlocked on game start, or not. By default, <see langword="true"/>.</param>
         /// <returns>The new <see cref="TechType"/> that is created.</returns>
         TechType ITechTypeHandler.AddTechType(string internalName, string displayName, string tooltip, bool unlockAtStart)
         {

--- a/SMLHelper/Handlers/TechTypeHandler.cs
+++ b/SMLHelper/Handlers/TechTypeHandler.cs
@@ -28,21 +28,22 @@
             // Hide constructor
         }
 
-        TechType ITechTypeHandlerInternal.AddTechType(string modName, string internalName, string displayName, string tooltip)
+        TechType ITechTypeHandlerInternal.AddTechType(Assembly assembly, string internalName, string displayName, string tooltip)
         {
-            return Singleton.AddTechType(modName, internalName, displayName, tooltip, true);
+            return Singleton.AddTechType(assembly, internalName, displayName, tooltip, true);
         }
 
-        TechType ITechTypeHandlerInternal.AddTechType(string modName, string internalName, string displayName, string tooltip, bool unlockAtStart)
+        TechType ITechTypeHandlerInternal.AddTechType(Assembly assembly, string internalName, string displayName, string tooltip, bool unlockAtStart)
         {
+            string modName = assembly.GetName().Name;
+            
             // Register the TechType.
-            TechType techType = TechTypePatcher.AddTechType(internalName);
-
+            var techType = TechTypePatcher.AddTechType(internalName);
+            
             // Remember which Assembly added it
-            Assembly mod = ReflectionHelper.CallingAssemblyByStackTrace();
-            TechTypesAddedBy[techType] = mod;
-
-            // Register Language lines.
+            TechTypesAddedBy[techType] = assembly;
+            
+            // register Language Lines.
             LanguagePatcher.AddCustomLanguageLine(modName, internalName, displayName);
             LanguagePatcher.AddCustomLanguageLine(modName, "Tooltip_" + internalName, tooltip);
 
@@ -59,6 +60,29 @@
 
         #region Static Methods
 
+        /// <summary>
+        /// Adds a new <see cref="TechType"/> into the game. This new <see cref="TechType"/> will be unlocked at the start of a game.
+        /// </summary>
+        /// <param name="addedByAssembly">The assembly this TechType is getting added by.</param>
+        /// <param name="internalName">The internal name of the TechType. Should not contain special characters</param>
+        /// <param name="displayName">The display name of the TechType. Can be anything.</param>
+        /// <param name="tooltip">The tooltip, displayed when hovered in an inventory. Can be anything.</param>
+        /// <returns>The new <see cref="TechType"/> that is created.</returns>
+        public static TechType AddTechType(Assembly addedByAssembly, string internalName, string displayName, string tooltip) =>
+            Singleton.AddTechType(addedByAssembly, internalName, displayName, tooltip);
+
+        /// <summary>
+        /// Adds a new <see cref="TechType"/> into the game.
+        /// </summary>
+        /// <param name="addedByAssembly">The assembly this TechType is getting added by.</param>
+        /// <param name="internalName">The internal name of the TechType. Should not contain special characters</param>
+        /// <param name="displayName">The display name of the TechType. Can be anything.</param>
+        /// <param name="tooltip">The tooltip, displayed when hovered in an inventory. Can be anything.</param>
+        /// <param name="unlockAtStart">Whether this TechType should be unlocked on game start, or not. By default, <see langword="true"/>.</param>
+        /// <returns>The new <see cref="TechType"/> that is created.</returns>
+        public static TechType AddTechType(Assembly addedByAssembly, string internalName, string displayName, string tooltip, bool unlockAtStart) =>
+            Singleton.AddTechType(addedByAssembly, internalName, displayName, tooltip, unlockAtStart);
+        
         /// <summary>
         /// Adds a new <see cref="TechType"/> into the game. This new techtype will be unlocked at the start of a the game.
         /// </summary>
@@ -186,8 +210,8 @@
         /// <returns>The new <see cref="TechType"/> that is created.</returns>
         TechType ITechTypeHandler.AddTechType(string internalName, string displayName, string tooltip, bool unlockAtStart)
         {
-            string modName = ReflectionHelper.CallingAssemblyNameByStackTrace();
-            return Singleton.AddTechType(modName, internalName, displayName, tooltip, unlockAtStart);
+            var mod = ReflectionHelper.CallingAssemblyByStackTrace();
+            return Singleton.AddTechType(mod, internalName, displayName, tooltip, unlockAtStart);
         }
 
         /// <summary>

--- a/SMLHelper/Handlers/TechTypeHandler.cs
+++ b/SMLHelper/Handlers/TechTypeHandler.cs
@@ -84,7 +84,7 @@
             Singleton.AddTechType(addedByAssembly, internalName, displayName, tooltip, unlockAtStart);
         
         /// <summary>
-        /// Adds a new <see cref="TechType"/> into the game. This new techtype will be unlocked at the start of a the game.
+        /// Adds a new <see cref="TechType"/> into the game. This new <see cref="TechType"/> will be unlocked at the start of a game.
         /// </summary>
         /// <param name="internalName">The internal name of the TechType. Should not contain special characters.</param>
         /// <param name="displayName">The display name of the TechType. Can be anything.</param>

--- a/SMLHelper/Interfaces/ITechTypeHandlerInternal.cs
+++ b/SMLHelper/Interfaces/ITechTypeHandlerInternal.cs
@@ -1,8 +1,10 @@
-﻿namespace SMLHelper.V2.Interfaces
+﻿using System.Reflection;
+
+namespace SMLHelper.V2.Interfaces
 {
     internal interface ITechTypeHandlerInternal : ITechTypeHandler
     {
-        TechType AddTechType(string modName, string internalName, string displayName, string tooltip);
-        TechType AddTechType(string modName, string internalName, string displayName, string tooltip, bool unlockAtStart);
+        TechType AddTechType(Assembly assembly, string internalName, string displayName, string tooltip);
+        TechType AddTechType(Assembly assembly, string internalName, string displayName, string tooltip, bool unlockAtStart);
     }
 }

--- a/SMLHelper/Interfaces/ITechTypeHandlerInternal.cs
+++ b/SMLHelper/Interfaces/ITechTypeHandlerInternal.cs
@@ -4,7 +4,7 @@ namespace SMLHelper.V2.Interfaces
 {
     internal interface ITechTypeHandlerInternal : ITechTypeHandler
     {
-        TechType AddTechType(Assembly assembly, string internalName, string displayName, string tooltip);
-        TechType AddTechType(Assembly assembly, string internalName, string displayName, string tooltip, bool unlockAtStart);
+        TechType AddTechType(Assembly modAssembly, string internalName, string displayName, string tooltip);
+        TechType AddTechType(Assembly modAssembly, string internalName, string displayName, string tooltip, bool unlockAtStart);
     }
 }


### PR DESCRIPTION
### Changes made in this pull request

  - ITechTypeHandlerInternal interface's AddTechType methods now need an Assembly instead of a string for the ModName.
  - Added 2 new methods to the TechTypeHandler for manual ModAssembly passing.
  - Adjusted the Assets classes TechType creation to fit the new system.
  
this changes will hopefully fix the issues for mod Libraries that encounter into SMLHelper giving them the wrong mod name for the TechType made by their Library for other mods.