### PR TITLE
C# 9.0 support

### DIFF
--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -14,7 +14,7 @@
     <AssemblyName>SMLHelper</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -283,6 +283,7 @@
     <Compile Include="Utility\KeyCodeUtils.cs" />
     <Compile Include="Utility\PatchUtils.cs" />
     <Compile Include="Utility\PlayerPrefsExtra.cs" />
+    <Compile Include="Utility\Polyfill.cs" />
     <Compile Include="Utility\PrefabUtils.cs" />
     <Compile Include="Utility\ReflectionHelper.cs" />
     <Compile Include="Utility\SaveUtils.cs" />

--- a/SMLHelper/Utility/Polyfill.cs
+++ b/SMLHelper/Utility/Polyfill.cs
@@ -1,0 +1,7 @@
+﻿// fix for C# 9.0 (for pre-5.0 .NET) for records and 'init' property modifiers
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit
+    {
+    }
+}


### PR DESCRIPTION
### Changes made in this pull request

  - `LangVersion` is changed to 9.0
  - `IsExternalInit` class is added to fix compiler errors when using records and `init` property modifier