### PR TITLE
Protected Process Prefab fix

### DIFF
--- a/SMLHelper/Assets/CustomFabricator.cs
+++ b/SMLHelper/Assets/CustomFabricator.cs
@@ -165,7 +165,8 @@
                 _ => null
             };
 
-            return ProcessPrefab(prefab);
+            ProcessPrefab(prefab);
+            return prefab;
 #endif
         }
 

--- a/SMLHelper/Assets/CustomFabricator.cs
+++ b/SMLHelper/Assets/CustomFabricator.cs
@@ -165,7 +165,7 @@
                 _ => null
             };
 
-            return ProcessPrefab(prefab);
+            return PreProcessPrefab(prefab);
 #endif
         }
 

--- a/SMLHelper/Assets/CustomFabricator.cs
+++ b/SMLHelper/Assets/CustomFabricator.cs
@@ -205,10 +205,15 @@
                     break;
             };
 
-            gameObject.Set(ProcessPrefab(prefab));
+            ProcessPrefab(prefab);
+            gameObject.Set(prefab);
         }
 
-        private GameObject ProcessPrefab(GameObject prefab)
+        /// <summary>
+        /// FOR ADVANCED MODDING ONLY. Do not override unless you know exactly what you are doing.
+        /// </summary>
+        /// <param name="prefab"></param>
+        protected override void ProcessPrefab(GameObject prefab)
         {
             Constructable constructible = null;
             GhostCrafter crafter;
@@ -282,8 +287,6 @@
             }
 
             crafter.powerRelay = PowerSource.FindRelay(prefab.transform);
-
-            return prefab;
         }
 
         /// <summary>

--- a/SMLHelper/Assets/CustomFabricator.cs
+++ b/SMLHelper/Assets/CustomFabricator.cs
@@ -205,10 +205,10 @@
                     break;
             };
 
-            gameObject.Set(ProcessPrefab(prefab));
+            gameObject.Set(PreProcessPrefab(prefab));
         }
 
-        private GameObject ProcessPrefab(GameObject prefab)
+        private GameObject PreProcessPrefab(GameObject prefab)
         {
             Constructable constructible = null;
             GhostCrafter crafter;

--- a/SMLHelper/Assets/CustomFabricator.cs
+++ b/SMLHelper/Assets/CustomFabricator.cs
@@ -165,8 +165,7 @@
                 _ => null
             };
 
-            ProcessPrefab(prefab);
-            return prefab;
+            return ProcessPrefab(prefab);
 #endif
         }
 

--- a/SMLHelper/Assets/CustomFabricator.cs
+++ b/SMLHelper/Assets/CustomFabricator.cs
@@ -205,15 +205,10 @@
                     break;
             };
 
-            ProcessPrefab(prefab);
-            gameObject.Set(prefab);
+            gameObject.Set(ProcessPrefab(prefab));
         }
 
-        /// <summary>
-        /// FOR ADVANCED MODDING ONLY. Do not override unless you know exactly what you are doing.
-        /// </summary>
-        /// <param name="prefab"></param>
-        protected override void ProcessPrefab(GameObject prefab)
+        private GameObject ProcessPrefab(GameObject prefab)
         {
             Constructable constructible = null;
             GhostCrafter crafter;
@@ -287,6 +282,8 @@
             }
 
             crafter.powerRelay = PowerSource.FindRelay(prefab.transform);
+
+            return prefab;
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes made in this pull request
  - Alters the `ProcessPrefab` method in `CustomFabricator` to comply with the change to `ModPrefab.ProcessPrefab` becoming `protected virtual` instead of `private` in #225.

## Builds cbde270
### Subnautica
[Stable](https://github.com/SubnauticaModding/SMLHelper/files/6761360/SMLHelper_SN.STABLE.zip)
[Experimental](https://github.com/SubnauticaModding/SMLHelper/files/6761362/SMLHelper_SN.EXP.zip)

### Below Zero
[Stable](https://github.com/SubnauticaModding/SMLHelper/files/6761364/SMLHelper_BZ.STABLE.zip)
[Experimental](https://github.com/SubnauticaModding/SMLHelper/files/6761380/SMLHelper_BZ.EXP.zip)
