### PR TITLE
`mod.json` version was missed in SMLHelper 2.10 PR.

### DIFF
--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.9.7",
+    "Version": "2.10",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.9.7",
+    "Version": "2.10",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll",


### PR DESCRIPTION
## Changes in this pull request
- Fixed `mod.json` version was not updated in #223. Missed it when reviewing.