### PR TITLE
Coordinated spawns hotfixes

### DIFF
--- a/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
+++ b/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
@@ -128,15 +128,15 @@ namespace SMLHelper.V2.Handlers
     public class SpawnInfo : IEquatable<SpawnInfo>
     {
         [JsonProperty]
-        internal TechType techType { get; }
+        internal TechType techType { get; init; }
         [JsonProperty]
-        internal string classId { get; }
+        internal string classId { get; init; }
         [JsonProperty]
-        internal Vector3 spawnPosition { get; }
+        internal Vector3 spawnPosition { get; init; }
         [JsonProperty]
-        internal Quaternion rotation { get; }
+        internal Quaternion rotation { get; init; }
         [JsonProperty]
-        internal SpawnType spawnType { get; }
+        internal SpawnType spawnType { get; init; }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -144,12 +144,7 @@ namespace SMLHelper.V2.Handlers
         /// <param name="techType">TechType to spawn.</param>
         /// <param name="spawnPosition">Position to spawn into.</param>
         public SpawnInfo(TechType techType, Vector3 spawnPosition)
-        {
-            this.techType = techType;
-            this.spawnPosition = spawnPosition;
-            this.rotation = Quaternion.identity;
-            spawnType = SpawnType.TechType;
-        }
+            : this(default, techType, spawnPosition, Quaternion.identity) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -157,12 +152,7 @@ namespace SMLHelper.V2.Handlers
         /// <param name="classId">ClassID to spawn.</param>
         /// <param name="spawnPosition">Position to spawn into.</param>
         public SpawnInfo(string classId, Vector3 spawnPosition)
-        {
-            this.classId = classId;
-            this.spawnPosition = spawnPosition;
-            this.rotation = Quaternion.identity;
-            spawnType = SpawnType.ClassId;
-        }
+            : this(classId, default, spawnPosition, Quaternion.identity) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -171,12 +161,7 @@ namespace SMLHelper.V2.Handlers
         /// <param name="spawnPosition">Position to spawn into.</param>
         /// <param name="rotation">Rotation to spawn at.</param>
         public SpawnInfo(TechType techType, Vector3 spawnPosition, Quaternion rotation)
-        {
-            this.techType = techType;
-            this.spawnPosition = spawnPosition;
-            this.rotation = rotation;
-            spawnType = SpawnType.TechType;
-        }
+            : this(default, techType, spawnPosition, rotation) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -185,12 +170,7 @@ namespace SMLHelper.V2.Handlers
         /// <param name="spawnPosition">Position to spawn into.</param>
         /// <param name="rotation">Rotation to spawn at.</param>
         public SpawnInfo(string classId, Vector3 spawnPosition, Quaternion rotation)
-        {
-            this.classId = classId;
-            this.spawnPosition = spawnPosition;
-            this.rotation = rotation;
-            spawnType = SpawnType.ClassId;
-        }
+            : this(classId, default, spawnPosition, rotation) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -199,12 +179,7 @@ namespace SMLHelper.V2.Handlers
         /// <param name="spawnPosition">Position to spawn into.</param>
         /// <param name="rotation">Rotation to spawn at.</param>
         public SpawnInfo(TechType techType, Vector3 spawnPosition, Vector3 rotation)
-        {
-            this.techType = techType;
-            this.spawnPosition = spawnPosition;
-            this.rotation = Quaternion.Euler(rotation);
-            spawnType = SpawnType.TechType;
-        }
+            : this(default, techType, spawnPosition, Quaternion.Euler(rotation)) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -213,12 +188,7 @@ namespace SMLHelper.V2.Handlers
         /// <param name="spawnPosition">Position to spawn into.</param>
         /// <param name="rotation">Rotation to spawn at.</param>
         public SpawnInfo(string classId, Vector3 spawnPosition, Vector3 rotation)
-        {
-            this.classId = classId;
-            this.spawnPosition = spawnPosition;
-            this.rotation = Quaternion.Euler(rotation);
-            spawnType = SpawnType.ClassId;
-        }
+            : this(classId, default, spawnPosition, Quaternion.Euler(rotation)) { }
 
         [JsonConstructor]
         internal SpawnInfo(string classId, TechType techType, Vector3 spawnPosition, Quaternion rotation)
@@ -227,7 +197,11 @@ namespace SMLHelper.V2.Handlers
             this.techType = techType;
             this.spawnPosition = spawnPosition;
             this.rotation = rotation;
-            spawnType = this.techType == TechType.None ? SpawnType.ClassId : SpawnType.TechType;
+            spawnType = this.techType switch
+            {
+                TechType.None => SpawnType.ClassId,
+                _ => SpawnType.TechType
+            };
         }
 
         /// <summary>

--- a/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
+++ b/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
@@ -123,20 +123,20 @@ namespace SMLHelper.V2.Handlers
 
     #region SpawnInfo
     /// <summary>
-    /// a basic class that provides enough info for the <see cref="CoordinatedSpawnsHandler"/> System to function.
+    /// A basic struct that provides enough info for the <see cref="CoordinatedSpawnsHandler"/> System to function.
     /// </summary>
-    public class SpawnInfo : IEquatable<SpawnInfo>
+    public struct SpawnInfo : IEquatable<SpawnInfo>
     {
         [JsonProperty]
-        internal TechType techType { get; init; }
+        internal TechType TechType { get; }
         [JsonProperty]
-        internal string classId { get; init; }
+        internal string ClassId { get; }
         [JsonProperty]
-        internal Vector3 spawnPosition { get; init; }
+        internal Vector3 SpawnPosition { get; }
         [JsonProperty]
-        internal Quaternion rotation { get; init; }
+        internal Quaternion Rotation { get; }
         [JsonProperty]
-        internal SpawnType spawnType { get; init; }
+        internal SpawnType Type { get; }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -193,11 +193,11 @@ namespace SMLHelper.V2.Handlers
         [JsonConstructor]
         internal SpawnInfo(string classId, TechType techType, Vector3 spawnPosition, Quaternion rotation)
         {
-            this.classId = classId;
-            this.techType = techType;
-            this.spawnPosition = spawnPosition;
-            this.rotation = rotation;
-            spawnType = this.techType switch
+            ClassId = classId;
+            TechType = techType;
+            SpawnPosition = spawnPosition;
+            Rotation = rotation;
+            Type = TechType switch
             {
                 default(TechType) => SpawnType.ClassId,
                 _ => SpawnType.TechType
@@ -205,25 +205,80 @@ namespace SMLHelper.V2.Handlers
         }
 
         /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <remarks>
+        /// It is worth noting that we use Unity's <see cref="Vector3.operator=="/> and <see cref="Quaternion.operator=="/>
+        /// operator comparisons for comparing the <see cref="SpawnPosition"/> and <see cref="Rotation"/> properties of each instance, 
+        /// to allow for an approximate comparison of these values.
+        /// </remarks>
+        /// <param name="obj">The object to compare with the current instance.</param>
+        /// <returns><see langword="true"/> if <paramref name="obj"/> is a <see cref="SpawnInfo"/> and represents the same
+        /// value as this instance; otherwise, <see langword="false"/>.</returns>
+        /// <seealso cref="Equals(SpawnInfo)"/>
+        public override bool Equals(object obj) => obj is SpawnInfo spawnInfo && Equals(spawnInfo);
+
+        /// <summary>
+        /// A custom hash code algorithm that takes into account the values of each property of the <see cref="SpawnInfo"/> instance,
+        /// and attempts to reduce diagonal collisions.
+        /// </summary>
+        /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
+        public override int GetHashCode()
+        {
+            unchecked // overflow is fine, just wrap around
+            {
+                int hash = 13;
+                hash = (hash * 7) + TechType.GetHashCode();
+                hash = (hash * 7) + ClassId.GetHashCode();
+                hash = (hash * 7) + SpawnPosition.GetHashCode();
+                hash = (hash * 7) + Rotation.GetHashCode();
+                hash = (hash * 7) + Type.GetHashCode();
+                return hash;
+            }
+        }
+
+        /// <summary>
         /// Indicates whether the current <see cref="SpawnInfo"/> is equal to another.
         /// </summary>
+        /// <remarks>
+        /// It is worth noting that we use Unity's <see cref="Vector3.operator=="/> and <see cref="Quaternion.operator=="/>
+        /// operator comparisons for comparing the <see cref="SpawnPosition"/> and <see cref="Rotation"/> properties of each instance, 
+        /// to allow for an approximate comparison of these values.
+        /// </remarks>
         /// <param name="other">The other <see cref="SpawnInfo"/>.</param>
         /// <returns><see langword="true"/> if the current <see cref="SpawnInfo"/> is equal to the <paramref name="other"/> parameter;
         /// otherwise <see langword="false"/>.</returns>
-        public bool Equals(SpawnInfo other)
-        {
-            return other.techType == techType
-                && other.classId == classId
-                && other.spawnPosition == spawnPosition
-                && other.rotation == rotation
-                && other.spawnType == spawnType;
-        }
+        public bool Equals(SpawnInfo other) => other.TechType == TechType
+                                            && other.ClassId == ClassId
+                                            && other.SpawnPosition == SpawnPosition
+                                            && other.Rotation == Rotation
+                                            && other.Type == Type;
 
         internal enum SpawnType
         {
             ClassId,
             TechType
         }
+
+        /// <summary>
+        /// Indicates whether two <see cref="SpawnInfo"/> instances are equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns><see langword="true"/> if the <see cref="SpawnInfo"/> instances are equal; otherwise, <see langword="false"/>.</returns>
+        /// <seealso cref="operator!="/>
+        /// <seealso cref="Equals(SpawnInfo)"/>
+        public static bool operator ==(SpawnInfo a, SpawnInfo b) => a.Equals(b);
+
+        /// <summary>
+        /// Indicates whether two <see cref="SpawnInfo"/> instances are not equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns><see langword="true"/> if the <see cref="SpawnInfo"/> instances are not equal; otherwise, <see langword="false"/>.</returns>
+        /// <seealso cref="operator=="/>
+        /// <seealso cref="Equals(SpawnInfo)"/>
+        public static bool operator !=(SpawnInfo a, SpawnInfo b) => !(a == b);
     }
     #endregion
 }

--- a/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
+++ b/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
@@ -221,12 +221,12 @@ namespace SMLHelper.V2.Handlers
         }
 
         [JsonConstructor]
-        internal SpawnInfo(string classId, TechType techType, Vector3 spawnPosition, Vector3 rotation)
+        internal SpawnInfo(string classId, TechType techType, Vector3 spawnPosition, Quaternion rotation)
         {
             this.classId = classId;
             this.techType = techType;
             this.spawnPosition = spawnPosition;
-            this.rotation = Quaternion.Euler(rotation);
+            this.rotation = rotation;
             spawnType = this.techType == TechType.None ? SpawnType.ClassId : SpawnType.TechType;
         }
 

--- a/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
+++ b/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
@@ -21,7 +21,7 @@ namespace SMLHelper.V2.Handlers
         /// Main entry point for all calls to this handler.
         /// </summary>
         public static ICoordinatedSpawnHandler Main { get; } = new CoordinatedSpawnsHandler();
-        
+
         private CoordinatedSpawnsHandler()
         {
             // Hide Constructor
@@ -116,11 +116,11 @@ namespace SMLHelper.V2.Handlers
         public static void RegisterCoordinatedSpawnsForOneTechType(TechType techTypeToSpawn, Dictionary<Vector3, Vector3> coordinatesAndRotationsToSpawnTo)
         {
             Main.RegisterCoordinatedSpawnsForOneTechType(techTypeToSpawn, coordinatesAndRotationsToSpawnTo);
-	}
+        }
 
         #endregion
     }
-    
+
     #region SpawnInfo
     /// <summary>
     /// a basic class that provides enough info for the <see cref="CoordinatedSpawnsHandler"/> System to function.
@@ -132,7 +132,7 @@ namespace SMLHelper.V2.Handlers
         [JsonProperty]
         internal string classId { get; }
         [JsonProperty]
-        internal Vector3 spawnPosition { get;  }
+        internal Vector3 spawnPosition { get; }
         [JsonProperty]
         internal Quaternion rotation { get; }
         [JsonProperty]
@@ -239,10 +239,11 @@ namespace SMLHelper.V2.Handlers
         {
             // this was necessary because the default Equality check was always giving a false positive.
             return obj is SpawnInfo spawnInfo
-                && spawnInfo.classId == this.classId 
-                && spawnInfo.rotation == this.rotation 
-                && spawnInfo.techType == this.techType 
-                && spawnInfo.spawnType == this.spawnType;
+                && spawnInfo.techType == techType
+                && spawnInfo.classId == classId
+                && spawnInfo.spawnPosition == spawnPosition
+                && spawnInfo.rotation == rotation
+                && spawnInfo.spawnType == spawnType;
         }
 
         /// <summary>
@@ -254,16 +255,17 @@ namespace SMLHelper.V2.Handlers
             // a simple GetHashCode implementation based on combinining the hashcodes of the fields used in the Equals equality check,
             // with an attempt to reduce diagonal collisions.
             int hash = 13;
-            hash = (hash * 7) + classId.GetHashCode();
-            hash = (hash * 7) + rotation.GetHashCode();
             hash = (hash * 7) + techType.GetHashCode();
+            hash = (hash * 7) + classId.GetHashCode();
+            hash = (hash * 7) + spawnPosition.GetHashCode();
+            hash = (hash * 7) + rotation.GetHashCode();
             hash = (hash * 7) + spawnType.GetHashCode();
             return hash;
         }
 
         internal enum SpawnType
         {
-            ClassId, 
+            ClassId,
             TechType
         }
     }

--- a/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
+++ b/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
@@ -199,7 +199,7 @@ namespace SMLHelper.V2.Handlers
             this.rotation = rotation;
             spawnType = this.techType switch
             {
-                TechType.None => SpawnType.ClassId,
+                default(TechType) => SpawnType.ClassId,
                 _ => SpawnType.TechType
             };
         }

--- a/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
+++ b/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
@@ -254,13 +254,17 @@ namespace SMLHelper.V2.Handlers
         {
             // a simple GetHashCode implementation based on combinining the hashcodes of the fields used in the Equals equality check,
             // with an attempt to reduce diagonal collisions.
-            int hash = 13;
-            hash = (hash * 7) + techType.GetHashCode();
-            hash = (hash * 7) + classId.GetHashCode();
-            hash = (hash * 7) + spawnPosition.GetHashCode();
-            hash = (hash * 7) + rotation.GetHashCode();
-            hash = (hash * 7) + spawnType.GetHashCode();
-            return hash;
+
+            unchecked // in the case of overflow, simply wrap around
+            {
+                int hash = 13;
+                hash = (hash * 7) + techType.GetHashCode();
+                hash = (hash * 7) + classId.GetHashCode();
+                hash = (hash * 7) + spawnPosition.GetHashCode();
+                hash = (hash * 7) + rotation.GetHashCode();
+                hash = (hash * 7) + spawnType.GetHashCode();
+                return hash;
+            }
         }
 
         internal enum SpawnType

--- a/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
+++ b/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
@@ -244,6 +244,16 @@ namespace SMLHelper.V2.Handlers
             return spawnInfo.classId == this.classId && spawnInfo.rotation == this.rotation && spawnInfo.techType == this.techType && spawnInfo.spawnType == this.spawnType;
         }
 
+        /// <summary>
+        /// Serves as the default hash function.
+        /// </summary>
+        /// <returns>A hash code for the current object.</returns>
+        public override int GetHashCode()
+        {
+            // this was required for C# to shut up
+            return base.GetHashCode();
+        }
+
         internal enum SpawnType
         {
             ClassId, 

--- a/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
+++ b/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
@@ -237,11 +237,12 @@ namespace SMLHelper.V2.Handlers
         /// <returns>true if equal; otherwise false.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is not SpawnInfo spawnInfo)
-                return false;
-
             // this was necessary because the default Equality check was always giving a false positive.
-            return spawnInfo.classId == this.classId && spawnInfo.rotation == this.rotation && spawnInfo.techType == this.techType && spawnInfo.spawnType == this.spawnType;
+            return obj is SpawnInfo spawnInfo
+                && spawnInfo.classId == this.classId 
+                && spawnInfo.rotation == this.rotation 
+                && spawnInfo.techType == this.techType 
+                && spawnInfo.spawnType == this.spawnType;
         }
 
         /// <summary>
@@ -250,8 +251,14 @@ namespace SMLHelper.V2.Handlers
         /// <returns>A hash code for the current object.</returns>
         public override int GetHashCode()
         {
-            // this was required for C# to shut up
-            return base.GetHashCode();
+            // a simple GetHashCode implementation based on combinining the hashcodes of the fields used in the Equals equality check,
+            // with an attempt to reduce diagonal collisions.
+            int hash = 13;
+            hash = (hash * 7) + classId.GetHashCode();
+            hash = (hash * 7) + rotation.GetHashCode();
+            hash = (hash * 7) + techType.GetHashCode();
+            hash = (hash * 7) + spawnType.GetHashCode();
+            return hash;
         }
 
         internal enum SpawnType

--- a/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
+++ b/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
@@ -1,16 +1,16 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+#if SUBNAUTICA_STABLE
+using Oculus.Newtonsoft.Json;
+#else
+using Newtonsoft.Json;
+#endif
 
 namespace SMLHelper.V2.Handlers
 {
-    using System.Collections.Generic;
     using Interfaces;
     using Patchers;
-    using UnityEngine;
-#if SUBNAUTICA_STABLE
-    using Oculus.Newtonsoft.Json;
-#else
-    using Newtonsoft.Json;
-#endif
-
 
     /// <summary>
     /// a Handler that handles and registers Coordinated (<see cref="Vector3"/> spawns).
@@ -125,7 +125,7 @@ namespace SMLHelper.V2.Handlers
     /// <summary>
     /// a basic class that provides enough info for the <see cref="CoordinatedSpawnsHandler"/> System to function.
     /// </summary>
-    public class SpawnInfo
+    public class SpawnInfo : IEquatable<SpawnInfo>
     {
         [JsonProperty]
         internal TechType techType { get; }
@@ -231,40 +231,18 @@ namespace SMLHelper.V2.Handlers
         }
 
         /// <summary>
-        /// Checks if the passed object is equal to the current object
+        /// Indicates whether the current <see cref="SpawnInfo"/> is equal to another.
         /// </summary>
-        /// <param name="obj">passed object</param>
-        /// <returns>true if equal; otherwise false.</returns>
-        public override bool Equals(object obj)
+        /// <param name="other">The other <see cref="SpawnInfo"/>.</param>
+        /// <returns><see langword="true"/> if the current <see cref="SpawnInfo"/> is equal to the <paramref name="other"/> parameter;
+        /// otherwise <see langword="false"/>.</returns>
+        public bool Equals(SpawnInfo other)
         {
-            // this was necessary because the default Equality check was always giving a false positive.
-            return obj is SpawnInfo spawnInfo
-                && spawnInfo.techType == techType
-                && spawnInfo.classId == classId
-                && spawnInfo.spawnPosition == spawnPosition
-                && spawnInfo.rotation == rotation
-                && spawnInfo.spawnType == spawnType;
-        }
-
-        /// <summary>
-        /// Serves as the default hash function.
-        /// </summary>
-        /// <returns>A hash code for the current object.</returns>
-        public override int GetHashCode()
-        {
-            // a simple GetHashCode implementation based on combinining the hashcodes of the fields used in the Equals equality check,
-            // with an attempt to reduce diagonal collisions.
-
-            unchecked // in the case of overflow, simply wrap around
-            {
-                int hash = 13;
-                hash = (hash * 7) + techType.GetHashCode();
-                hash = (hash * 7) + classId.GetHashCode();
-                hash = (hash * 7) + spawnPosition.GetHashCode();
-                hash = (hash * 7) + rotation.GetHashCode();
-                hash = (hash * 7) + spawnType.GetHashCode();
-                return hash;
-            }
+            return other.techType == techType
+                && other.classId == classId
+                && other.spawnPosition == spawnPosition
+                && other.rotation == rotation
+                && other.spawnType == spawnType;
         }
 
         internal enum SpawnType

--- a/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
+++ b/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
@@ -220,6 +220,30 @@ namespace SMLHelper.V2.Handlers
             spawnType = SpawnType.ClassId;
         }
 
+        [JsonConstructor]
+        internal SpawnInfo(string classId, TechType techType, Vector3 spawnPosition, Vector3 rotation)
+        {
+            this.classId = classId;
+            this.techType = techType;
+            this.spawnPosition = spawnPosition;
+            this.rotation = Quaternion.Euler(rotation);
+            spawnType = this.techType == TechType.None ? SpawnType.ClassId : SpawnType.TechType;
+        }
+
+        /// <summary>
+        /// Checks if the passed object is equal to the current object
+        /// </summary>
+        /// <param name="obj">passed object</param>
+        /// <returns>true if equal; otherwise false.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is not SpawnInfo spawnInfo)
+                return false;
+
+            // this was necessary because the default Equality check was always giving a false positive.
+            return spawnInfo.classId == this.classId && spawnInfo.rotation == this.rotation && spawnInfo.techType == this.techType && spawnInfo.spawnType == this.spawnType;
+        }
+
         internal enum SpawnType
         {
             ClassId, 

--- a/SMLHelper/Json/Converters/QuaternionConverter.cs
+++ b/SMLHelper/Json/Converters/QuaternionConverter.cs
@@ -10,7 +10,7 @@ namespace SMLHelper.V2.Json.Converters
     /// <summary>
     /// A Quaternion json converter that simplifies the Vector3 to only x,y,z serialization.
     /// </summary>
-    class QuaternionConverter : JsonConverter
+    public class QuaternionConverter : JsonConverter
     {
         /// <summary>
         /// A method that determines when this converter should process.

--- a/SMLHelper/Json/Converters/QuaternionConverter.cs
+++ b/SMLHelper/Json/Converters/QuaternionConverter.cs
@@ -31,8 +31,7 @@ namespace SMLHelper.V2.Json.Converters
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var quaternion = (Quaternion)value;
-
-            serializer.Serialize(writer, new QuaternionJson(quaternion.x, quaternion.y, quaternion.z, quaternion.w));
+            serializer.Serialize(writer, (QuaternionJson)quaternion);
         }
 
         /// <summary>
@@ -45,11 +44,13 @@ namespace SMLHelper.V2.Json.Converters
         /// <returns></returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var q = serializer.Deserialize<QuaternionJson>(reader);
-
-            return new Quaternion(q.X, q.Y, q.X, q.W);
+            return (Quaternion)serializer.Deserialize<QuaternionJson>(reader);
         }
     }
 
-    internal record QuaternionJson(float X, float Y, float Z, float W);
+    internal record QuaternionJson(float X, float Y, float Z, float W)
+    {
+        public static explicit operator Quaternion(QuaternionJson q) => new(q.X, q.Y, q.Z, q.W);
+        public static explicit operator QuaternionJson(Quaternion q) => new(q.x, q.y, q.z, q.w);
+    }
 }

--- a/SMLHelper/Json/Converters/QuaternionConverter.cs
+++ b/SMLHelper/Json/Converters/QuaternionConverter.cs
@@ -51,19 +51,5 @@ namespace SMLHelper.V2.Json.Converters
         }
     }
 
-    struct QuaternionJson
-    {
-        internal float x;
-        internal float y;
-        internal float z;
-        internal float w;
-
-        public QuaternionJson(float x, float y, float z, float w)
-        {
-            this.x = x;
-            this.y = y;
-            this.z = z;
-            this.w = w;
-        }
-    }
+    internal record QuaternionJson(float x, float y, float z, float w);
 }

--- a/SMLHelper/Json/Converters/QuaternionConverter.cs
+++ b/SMLHelper/Json/Converters/QuaternionConverter.cs
@@ -47,9 +47,9 @@ namespace SMLHelper.V2.Json.Converters
         {
             var q = serializer.Deserialize<QuaternionJson>(reader);
 
-            return new Quaternion(q.x, q.y, q.z, q.w);
+            return new Quaternion(q.X, q.Y, q.X, q.W);
         }
     }
 
-    internal record QuaternionJson(float x, float y, float z, float w);
+    internal record QuaternionJson(float X, float Y, float Z, float W);
 }

--- a/SMLHelper/Json/Converters/QuaternionConverter.cs
+++ b/SMLHelper/Json/Converters/QuaternionConverter.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using UnityEngine;
+#if SUBNAUTICA
+using Oculus.Newtonsoft.Json;
+#else
+using Newtonsoft.Json;
+#endif
+namespace SMLHelper.V2.Json.Converters
+{
+    /// <summary>
+    /// A Quaternion json converter that simplifies the Vector3 to only x,y,z serialization.
+    /// </summary>
+    class QuaternionConverter : JsonConverter
+    {
+        /// <summary>
+        /// A method that determines when this converter should process.
+        /// </summary>
+        /// <param name="objectType">the current object type</param>
+        /// <returns></returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Quaternion);
+        }
+
+        /// <summary>
+        /// A method that tells Newtonsoft how to Serialize the current object.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
+        /// <param name="serializer"></param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var quaternion = (Quaternion)value;
+
+            serializer.Serialize(writer, new QuaternionJson(quaternion.x, quaternion.y, quaternion.z, quaternion.w));
+        }
+
+        /// <summary>
+        /// A method that tells Newtonsoft how to Deserialize and read the current object.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="objectType"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="serializer"></param>
+        /// <returns></returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var q = (QuaternionJson)serializer.Deserialize(reader, typeof(QuaternionJson));
+
+            return new Quaternion(q.x, q.y, q.z, q.w);
+        }
+    }
+
+    struct QuaternionJson
+    {
+        internal float x;
+        internal float y;
+        internal float z;
+        internal float w;
+
+        public QuaternionJson(float x, float y, float z, float w)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
+        }
+    }
+}

--- a/SMLHelper/Json/Converters/QuaternionConverter.cs
+++ b/SMLHelper/Json/Converters/QuaternionConverter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using UnityEngine;
-#if SUBNAUTICA
-using Oculus.Newtonsoft.Json;
+#if SUBNAUTICA_STABLE
+    using Oculus.Newtonsoft.Json;
 #else
 using Newtonsoft.Json;
 #endif

--- a/SMLHelper/Json/Converters/QuaternionConverter.cs
+++ b/SMLHelper/Json/Converters/QuaternionConverter.cs
@@ -45,7 +45,7 @@ namespace SMLHelper.V2.Json.Converters
         /// <returns></returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var q = (QuaternionJson)serializer.Deserialize(reader, typeof(QuaternionJson));
+            var q = serializer.Deserialize<QuaternionJson>(reader);
 
             return new Quaternion(q.x, q.y, q.z, q.w);
         }

--- a/SMLHelper/Json/Converters/Vector3Converter.cs
+++ b/SMLHelper/Json/Converters/Vector3Converter.cs
@@ -51,17 +51,5 @@ namespace SMLHelper.V2.Json.Converters
         }
     }
 
-    struct Vector3Json
-    {
-        public float x;
-        public float y;
-        public float z;
-
-        public Vector3Json(float x, float y, float z)
-        {
-            this.x = x;
-            this.y = y;
-            this.z = z;
-        }
-    }
+    internal record Vector3Json(float x, float y, float z);
 }

--- a/SMLHelper/Json/Converters/Vector3Converter.cs
+++ b/SMLHelper/Json/Converters/Vector3Converter.cs
@@ -31,8 +31,7 @@ namespace SMLHelper.V2.Json.Converters
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var vector3 = (Vector3)value;
-
-            serializer.Serialize(writer, new Vector3Json(vector3.x, vector3.y, vector3.z));
+            serializer.Serialize(writer, (Vector3Json)vector3);
         }
 
         /// <summary>
@@ -45,11 +44,13 @@ namespace SMLHelper.V2.Json.Converters
         /// <returns></returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var v = serializer.Deserialize<Vector3Json>(reader);
-
-            return new Vector3(v.X, v.Y, v.Z);
+            return (Vector3)serializer.Deserialize<Vector3Json>(reader);
         }
     }
 
-    internal record Vector3Json(float X, float Y, float Z);
+    internal record Vector3Json(float X, float Y, float Z)
+    {
+        public static explicit operator Vector3(Vector3Json v) => new(v.X, v.Y, v.Z);
+        public static explicit operator Vector3Json(Vector3 v) => new(v.x, v.y, v.z);
+    }
 }

--- a/SMLHelper/Json/Converters/Vector3Converter.cs
+++ b/SMLHelper/Json/Converters/Vector3Converter.cs
@@ -10,7 +10,7 @@ namespace SMLHelper.V2.Json.Converters
     /// <summary>
     /// A Vector3 json converter that simplifies the Vector3 to only x,y,z serialization.
     /// </summary>
-    class Vector3Converter : JsonConverter
+    public class Vector3Converter : JsonConverter
     {
         /// <summary>
         /// A method that determines when this converter should process.

--- a/SMLHelper/Json/Converters/Vector3Converter.cs
+++ b/SMLHelper/Json/Converters/Vector3Converter.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using UnityEngine;
+#if SUBNAUTICA
+using Oculus.Newtonsoft.Json;
+#else
+using Newtonsoft.Json;
+#endif
+namespace SMLHelper.V2.Json.Converters
+{
+    /// <summary>
+    /// A Vector3 json converter that simplifies the Vector3 to only x,y,z serialization.
+    /// </summary>
+    class Vector3Converter : JsonConverter
+    {
+        /// <summary>
+        /// A method that determines when this converter should process.
+        /// </summary>
+        /// <param name="objectType">the current object type</param>
+        /// <returns></returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Vector3);
+        }
+
+        /// <summary>
+        /// A method that tells Newtonsoft how to Serialize the current object.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
+        /// <param name="serializer"></param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var vector3 = (Vector3)value;
+
+            serializer.Serialize(writer, new Vector3Json(vector3.x, vector3.y, vector3.z));
+        }
+
+        /// <summary>
+        /// A method that tells Newtonsoft how to Deserialize and read the current object.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="objectType"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="serializer"></param>
+        /// <returns></returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var v = (Vector3Json)serializer.Deserialize(reader, typeof(Vector3Json));
+
+            return new Vector3(v.x, v.y, v.z);
+        }
+    }
+
+    struct Vector3Json
+    {
+        public float x;
+        public float y;
+        public float z;
+
+        public Vector3Json(float x, float y, float z)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+    }
+}

--- a/SMLHelper/Json/Converters/Vector3Converter.cs
+++ b/SMLHelper/Json/Converters/Vector3Converter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using UnityEngine;
-#if SUBNAUTICA
+#if SUBNAUTICA_STABLE
 using Oculus.Newtonsoft.Json;
 #else
 using Newtonsoft.Json;

--- a/SMLHelper/Json/Converters/Vector3Converter.cs
+++ b/SMLHelper/Json/Converters/Vector3Converter.cs
@@ -47,9 +47,9 @@ namespace SMLHelper.V2.Json.Converters
         {
             var v = serializer.Deserialize<Vector3Json>(reader);
 
-            return new Vector3(v.x, v.y, v.z);
+            return new Vector3(v.X, v.Y, v.Z);
         }
     }
 
-    internal record Vector3Json(float x, float y, float z);
+    internal record Vector3Json(float X, float Y, float Z);
 }

--- a/SMLHelper/Json/Converters/Vector3Converter.cs
+++ b/SMLHelper/Json/Converters/Vector3Converter.cs
@@ -45,7 +45,7 @@ namespace SMLHelper.V2.Json.Converters
         /// <returns></returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var v = (Vector3Json)serializer.Deserialize(reader, typeof(Vector3Json));
+            var v = serializer.Deserialize<Vector3Json>(reader);
 
             return new Vector3(v.x, v.y, v.z);
         }

--- a/SMLHelper/MonoBehaviours/EntitySpawner.cs
+++ b/SMLHelper/MonoBehaviours/EntitySpawner.cs
@@ -10,19 +10,20 @@ namespace SMLHelper.V2.MonoBehaviours
     internal class EntitySpawner : MonoBehaviour
     {
         internal SpawnInfo spawnInfo;
-        
 
-        void Start() 
-        { 
+        void Start()
+        {
             StartCoroutine(SpawnAsync());
         }
 
         IEnumerator SpawnAsync()
         {
-            var stringToLog = spawnInfo.spawnType == SpawnInfo.SpawnType.ClassId
-                ? spawnInfo.classId
-                : spawnInfo.techType.ToString();
-            
+            var stringToLog = spawnInfo.Type switch
+            {
+                SpawnInfo.SpawnType.ClassId => spawnInfo.ClassId,
+                _ => spawnInfo.TechType.AsString()
+            };
+
             var task = new TaskResult<GameObject>();
             yield return GetPrefabAsync(task);
 
@@ -35,7 +36,7 @@ namespace SMLHelper.V2.MonoBehaviours
             }
 
 
-            var obj = Utils.InstantiateDeactivated(prefab, spawnInfo.spawnPosition, spawnInfo.rotation);
+            var obj = Utils.InstantiateDeactivated(prefab, spawnInfo.SpawnPosition, spawnInfo.Rotation);
 
             var lwe = obj.GetComponent<LargeWorldEntity>();
 
@@ -44,38 +45,38 @@ namespace SMLHelper.V2.MonoBehaviours
             {
                 var lws = LargeWorldStreamer.main;
                 yield return new WaitUntil(() => lws.IsReady()); // first we make sure the world streamer is initialized
-                var batch = lws.GetContainingBatch(spawnInfo.spawnPosition);
+                var batch = lws.GetContainingBatch(spawnInfo.SpawnPosition);
                 yield return new WaitUntil(() => lws.IsBatchReadyToCompile(batch)); // then we wait until the terrain is fully loaded (must be checked on each frame for faster spawns)
             }
 
             LargeWorld.main.streamer.cellManager.RegisterEntity(obj);
-            
+
             obj.SetActive(true);
 
             LargeWorldStreamerPatcher.savedSpawnInfos.Add(spawnInfo);
-            
+
             Destroy(gameObject);
         }
 
         IEnumerator GetPrefabAsync(IOut<GameObject> gameObject)
         {
             GameObject obj;
-            
-            if (spawnInfo.spawnType == SpawnInfo.SpawnType.ClassId) // Spawn is via ClassID.
+
+            if (spawnInfo.Type == SpawnInfo.SpawnType.ClassId) // Spawn is via ClassID.
             {
-                var request = PrefabDatabase.GetPrefabAsync(spawnInfo.classId);
+                var request = PrefabDatabase.GetPrefabAsync(spawnInfo.ClassId);
                 yield return request;
 
                 request.TryGetPrefab(out obj);
             }
             else // spawn is via TechType.
             {
-                var task = CraftData.GetPrefabForTechTypeAsync(spawnInfo.techType);
+                var task = CraftData.GetPrefabForTechTypeAsync(spawnInfo.TechType);
                 yield return task;
 
                 obj = task.GetResult();
             }
-            
+
             gameObject.Set(obj);
         }
     }

--- a/SMLHelper/MonoBehaviours/EntitySpawner.cs
+++ b/SMLHelper/MonoBehaviours/EntitySpawner.cs
@@ -40,7 +40,7 @@ namespace SMLHelper.V2.MonoBehaviours
             var lwe = obj.GetComponent<LargeWorldEntity>();
 
             // non-global objects cannot be spawned in unloaded terrain so we need to wait
-            if (lwe == null || lwe?.cellLevel is not (LargeWorldEntity.CellLevel.Batch or LargeWorldEntity.CellLevel.Global))
+            if (lwe == null || lwe.cellLevel is not (LargeWorldEntity.CellLevel.Batch or LargeWorldEntity.CellLevel.Global))
             {
                 var lws = LargeWorldStreamer.main;
                 yield return new WaitUntil(() => lws.IsReady()); // first we make sure the world streamer is initialized

--- a/SMLHelper/MonoBehaviours/EntitySpawner.cs
+++ b/SMLHelper/MonoBehaviours/EntitySpawner.cs
@@ -40,7 +40,7 @@ namespace SMLHelper.V2.MonoBehaviours
             var lwe = obj.GetComponent<LargeWorldEntity>();
 
             // non-global objects cannot be spawned in unloaded terrain so we need to wait
-            if (lwe == null || lwe.cellLevel is not (LargeWorldEntity.CellLevel.Batch or LargeWorldEntity.CellLevel.Global))
+            if (lwe == null || lwe?.cellLevel is not (LargeWorldEntity.CellLevel.Batch or LargeWorldEntity.CellLevel.Global))
             {
                 var lws = LargeWorldStreamer.main;
                 yield return new WaitUntil(() => lws.IsReady()); // first we make sure the world streamer is initialized

--- a/SMLHelper/Patchers/LargeWorldStreamerPatcher.cs
+++ b/SMLHelper/Patchers/LargeWorldStreamerPatcher.cs
@@ -10,7 +10,7 @@ namespace SMLHelper.V2.Patchers
     using Handlers;
     using MonoBehaviours;
     using UnityEngine;
- #if SUBNAUTICA_STABLE
+#if SUBNAUTICA_STABLE
     using Oculus.Newtonsoft.Json;
 #else
     using Newtonsoft.Json;
@@ -25,10 +25,10 @@ namespace SMLHelper.V2.Patchers
 
             harmony.Patch(initializeOriginal, postfix: postfix);
         }
-        
+
         internal static readonly List<SpawnInfo> spawnInfos = new List<SpawnInfo>();
         internal static readonly List<SpawnInfo> savedSpawnInfos = new List<SpawnInfo>();
-        
+
         private static void InitializePostfix()
         {
             var file = Path.Combine(SaveLoadManager.GetTemporarySavePath(), "CoordinatedSpawnsInitialized.smlhelper");
@@ -36,14 +36,14 @@ namespace SMLHelper.V2.Patchers
             {
                 // already initialized, return to prevent from spawn duplications.
                 Logger.Debug("Coordinated Spawns already been spawned in the current save. Loading Data");
-                
+
                 using var reader = new StreamReader(file);
                 try
                 {
                     var deserializedList = JsonConvert.DeserializeObject<List<SpawnInfo>>(reader.ReadToEnd(), new Vector3Converter(), new QuaternionConverter());
                     if (deserializedList is not null)
                         savedSpawnInfos.AddRange(deserializedList);
-					
+
                     reader.Close();
                 }
                 catch (Exception ex)
@@ -92,12 +92,16 @@ namespace SMLHelper.V2.Patchers
             }
         }
 
-        private static void CreateSpawner(SpawnInfo sp)
+        private static void CreateSpawner(SpawnInfo spawnInfo)
         {
-            var keyToCheck = sp.spawnType == SpawnInfo.SpawnType.TechType ? sp.techType.AsString() : sp.classId;
-            
+            var keyToCheck = spawnInfo.Type switch
+            {
+                SpawnInfo.SpawnType.TechType => spawnInfo.TechType.AsString(),
+                _ => spawnInfo.ClassId
+            };
+
             var obj = new GameObject($"{keyToCheck}Spawner");
-            obj.EnsureComponent<EntitySpawner>().spawnInfo = sp;
+            obj.EnsureComponent<EntitySpawner>().spawnInfo = spawnInfo;
         }
     }
 }

--- a/SMLHelper/Patchers/LargeWorldStreamerPatcher.cs
+++ b/SMLHelper/Patchers/LargeWorldStreamerPatcher.cs
@@ -3,6 +3,7 @@ namespace SMLHelper.V2.Patchers
     using System;
     using System.Linq;
     using Logger = Logger;
+    using Json.Converters;
     using System.Collections.Generic;
     using System.IO;
     using HarmonyLib;
@@ -39,7 +40,7 @@ namespace SMLHelper.V2.Patchers
                 using var reader = new StreamReader(file);
                 try
                 {
-                    var deserializedList = JsonConvert.DeserializeObject<List<SpawnInfo>>(reader.ReadToEnd());
+                    var deserializedList = JsonConvert.DeserializeObject<List<SpawnInfo>>(reader.ReadToEnd(), new Vector3Converter(), new QuaternionConverter());
                     if (deserializedList is not null)
                         savedSpawnInfos.AddRange(deserializedList);
 					
@@ -58,7 +59,7 @@ namespace SMLHelper.V2.Patchers
                 if (spawnInfos.Contains(savedSpawnInfo))
                     spawnInfos.Remove(savedSpawnInfo);
             }
-            
+
             IngameMenuHandler.RegisterOneTimeUseOnSaveEvent(() => SaveData(file));
 
             Initialize();
@@ -70,8 +71,7 @@ namespace SMLHelper.V2.Patchers
             using var writer = new StreamWriter(file);
             try
             {
-                string data = JsonConvert.SerializeObject(savedSpawnInfos, Formatting.Indented,
-                    new JsonSerializerSettings() {ReferenceLoopHandling = ReferenceLoopHandling.Ignore});
+                string data = JsonConvert.SerializeObject(savedSpawnInfos, Formatting.Indented, new Vector3Converter(), new QuaternionConverter());
                 //Logger.Info(data);
                 writer.Write(data);
                 writer.Flush();

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.0.5")]
-[assembly: AssemblyFileVersion("2.10.0.5")]
+[assembly: AssemblyVersion("2.10.0.6")]
+[assembly: AssemblyFileVersion("2.10.0.6")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.0.4")]
-[assembly: AssemblyFileVersion("2.10.0.4")]
+[assembly: AssemblyVersion("2.10.0.5")]
+[assembly: AssemblyFileVersion("2.10.0.5")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.0.1")]
-[assembly: AssemblyFileVersion("2.10.0.1")]
+[assembly: AssemblyVersion("2.10.0.2")]
+[assembly: AssemblyFileVersion("2.10.0.2")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.0.0")]
-[assembly: AssemblyFileVersion("2.10.0.0")]
+[assembly: AssemblyVersion("2.10.0.1")]
+[assembly: AssemblyFileVersion("2.10.0.1")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.0.3")]
-[assembly: AssemblyFileVersion("2.10.0.3")]
+[assembly: AssemblyVersion("2.10.0.4")]
+[assembly: AssemblyFileVersion("2.10.0.4")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.0.2")]
-[assembly: AssemblyFileVersion("2.10.0.2")]
+[assembly: AssemblyVersion("2.10.0.3")]
+[assembly: AssemblyFileVersion("2.10.0.3")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -168,6 +168,8 @@
     <Compile Include="Interfaces\ITechGroupHandler.cs" />
     <Compile Include="Json\ConfigFileAttribute.cs" />
     <Compile Include="Json\Converters\FloatConverter.cs" />
+    <Compile Include="Json\Converters\QuaternionConverter.cs" />
+    <Compile Include="Json\Converters\Vector3Converter.cs" />
     <Compile Include="Json\ExtensionMethods\JsonExtensions.cs" />
     <Compile Include="Handler.cs" />
     <Compile Include="Handlers\BioReactorHandler.cs" />

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.0.4",
+    "Version": "2.10.0.5",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.0.2",
+    "Version": "2.10.0.3",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.0",
+    "Version": "2.10.0.1",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.0.5",
+    "Version": "2.10.0.6",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.0.3",
+    "Version": "2.10.0.4",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.0.1",
+    "Version": "2.10.0.2",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.0.1",
+    "Version": "2.10.0.2",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.0.3",
+    "Version": "2.10.0.4",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.0.4",
+    "Version": "2.10.0.5",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.0",
+    "Version": "2.10.0.1",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.0.5",
+    "Version": "2.10.0.6",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.0.2",
+    "Version": "2.10.0.3",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll",


### PR DESCRIPTION
## Changes made in this pull request

  - Fixed a bug where the savedSpawns Deserializer was failing.
  - Added two new `public` `JsonConverter` classes (`QuaternionConverter`/`Vector3Converter`) for simplified serializations.
  - Redesigned `SpawnInfo` into a `struct`, implementing `IEquatable<SpawnInfo>`, custom `Equals`, `GetHashCode` methods and operator overloads for `==` and `!=` respectively.
  - Fixes an issue where `EntitySpawner.SpawnAsync` was using `TechType.ToString()` rather than `TechType.AsString()`.

## Builds by @tobeyStraitjacket 
### 5555948 v2.10.0.3: `Equals(object obj)` & `GetHashCode()`
- This build features an implementation as initially intended by @Metious which overrides `Equals(object obj)` & `GetHashCode()` to provide a value-based equality comparison for all properties of `SpawnInfo`.
- As it overrides `Equals` and `GetHashCode` to provide value-based equality comparison, this is a breaking change for anyone who previously relied on `Equals` or `GetHashCode` (particularly a problem in the case of `HashSet`), but it solves the problem where `List.Contains` is returning `false` for deserialized `SpawnInfo` instances. However, it also means that we cannot later change the implementation of `Equals` or `GetHashCode` without another breaking change for consumers.

#### Subnautica
[Stable v2.10.0.3](https://github.com/SubnauticaModding/SMLHelper/files/6768155/SMLHelper_SN.STABLE_v2.10.0.3.zip)
[Experimental v2.10.0.3](https://github.com/SubnauticaModding/SMLHelper/files/6768157/SMLHelper_SN.EXP_v2.10.0.3.zip)

#### Below Zero
[Stable v2.10.0.3](https://github.com/SubnauticaModding/SMLHelper/files/6768159/SMLHelper_BZ.STABLE_v2.10.0.3.zip)
[Experimental v2.10.0.3](https://github.com/SubnauticaModding/SMLHelper/files/6768161/SMLHelper_BZ.EXP_v2.10.0.3.zip)

### 96cdaa3 v2.10.0.5: `IEquatable<SpawnInfo>` `Equals(SpawnInfo other)`
- This build does not override `Equals(object obj)` or `GetHashCode`, but instead implements `IEquatable<SpawnInfo>` and `Equals(SpawnInfo other)` to provide a value-based equality comparison for all properties of `SpawnInfo`.
- `List.Contains` should defer to`Equals(SpawnInfo)` for comparison since we implement `IEquatable<SpawnInfo>`, and the issue @Metious was trying to solve should be resolved.
- This should make for a less egregious backwards-incompatible change, as `Equals(object obj)` and `GetHashCode` still operate the same, it is only `Equals(SpawnInfo other)` that has been changed. Still, the issue remains that if we change this in future, it will have implications for consumers, so it must be approached with caution.

#### Subnautica
[Stable v2.10.0.5](https://github.com/SubnauticaModding/SMLHelper/files/6768741/SMLHelper_SN.STABLE_v2.10.0.5.zip)
[Experimental v2.10.0.5](https://github.com/SubnauticaModding/SMLHelper/files/6768745/SMLHelper_SN.EXP_v2.10.0.5.zip)

#### Below Zero
[Stable v2.10.0.5](https://github.com/SubnauticaModding/SMLHelper/files/6768747/SMLHelper_BZ.STABLE_v2.10.0.5.zip)
[Experimental v2.10.0.5](https://github.com/SubnauticaModding/SMLHelper/files/6768749/SMLHelper_BZ.EXP_v2.10.0.5.zip)

### b9802ce v2.10.0.6: `SpawnInfo` redesigned as a `struct`
- This build combines the logic of both 2.10.0.3 and 2.10.0.5, and on top of that, also redesigns `SpawnInfo` as a `struct` rather than a `class`.
- @Metious assures me that nobody outside of himself and the RotA team are making any use of the `SpawnInfo` API, so a backwards-incompatible change that fixes the design of the API is preferable, should this prove to be true.

### Subnautica
[Stable v2.10.0.6](https://github.com/SubnauticaModding/SMLHelper/files/6770222/SMLHelper_SN.STABLE_v2.10.0.6.zip)
[Experimental v2.10.0.6](https://github.com/SubnauticaModding/SMLHelper/files/6770224/SMLHelper_SN.EXP_v2.10.0.6.zip)

### Below Zero
[Stable v2.10.0.6](https://github.com/SubnauticaModding/SMLHelper/files/6770230/SMLHelper_BZ.STABLE_v2.10.0.6.zip)
[Experimental v2.10.0.6](https://github.com/SubnauticaModding/SMLHelper/files/6770231/SMLHelper_BZ.EXP_v2.10.0.6.zip)

## Builds by @Metious ca7018a
[SMLHelper_BZ.STABLE.zip](https://github.com/SubnauticaModding/SMLHelper/files/6765975/SMLHelper_BZ.STABLE.zip)
[SMLHelper_BZ.STABLE.zip](https://github.com/SubnauticaModding/SMLHelper/files/6765975/SMLHelper_BZ.STABLE.zip)