### PR TITLE
Menu options showing incorrect chosen value for enum-based `[Choice]` when using custom `string` names.

### DIFF
--- a/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
+++ b/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
@@ -126,7 +126,6 @@
                 string[] options = choiceAttribute.Options;
                 string name = memberInfoMetadata.GetValue(ConfigFileMetadata.Config).ToString();
                 int index = Math.Max(Array.IndexOf(Enum.GetNames(memberInfoMetadata.ValueType), name), 0);
-
                 AddChoiceOption(id, label, options, index);
             }
             else if (memberInfoMetadata.ValueType == typeof(string))

--- a/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
+++ b/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
@@ -124,8 +124,9 @@
             {
                 // Enum-based choice where the values are defined as custom strings
                 string[] options = choiceAttribute.Options;
-                string value = memberInfoMetadata.GetValue(ConfigFileMetadata.Config).ToString();
-                int index = Math.Max(Array.IndexOf(Enum.GetValues(memberInfoMetadata.ValueType), value), 0);
+                string name = memberInfoMetadata.GetValue(ConfigFileMetadata.Config).ToString();
+                int index = Math.Max(Array.IndexOf(Enum.GetNames(memberInfoMetadata.ValueType), name), 0);
+
                 AddChoiceOption(id, label, options, index);
             }
             else if (memberInfoMetadata.ValueType == typeof(string))


### PR DESCRIPTION
## Changes made in this pull request
  - Resolves an issue where passing custom `string` names for enum-based `Choice` was incorrectly displaying the choice as if the first option was selected when the menu is first built, regardless of what option is actually selected.

Example:
```cs
[Choice(label: "Desired fullscreen mode",
        "Exclusive fullscreen", "Windowed fullscreen", "Windowed")]
public FullscreenMode DesiredFullscreenMode { get; set; } = FullscreenMode.WindowedFullscreen;

public enum FullscreenMode
{
    ExclusiveFullscreen,
    WindowedFullscreen,
    Windowed
}
```
In the above instance, on first load, despite the fact the default is `WindowedFullscreen`, SMLHelper is always assuming it is the 0 index when the mod options are built ("Exclusive fullscreen").

## Builds 9e54041
### Subnautica
[Stable](https://github.com/SubnauticaModding/SMLHelper/files/6784125/SMLHelper_SN.STABLE.zip)
[Experimental](https://github.com/SubnauticaModding/SMLHelper/files/6784128/SMLHelper_SN.EXP.zip)

### Below Zero
[Stable](https://github.com/SubnauticaModding/SMLHelper/files/6784130/SMLHelper_BZ.STABLE.zip)
[Experimental](https://github.com/SubnauticaModding/SMLHelper/files/6784131/SMLHelper_BZ.EXP.zip)
