### PR TITLE
Defer `ConfigFile` attribute-based events when using the `OptionsMenuBuilder` via `RegisterModOptions<ConfigFile>`.

### DIFF
--- a/SMLHelper/Handlers/OptionsPanelHandler.cs
+++ b/SMLHelper/Handlers/OptionsPanelHandler.cs
@@ -65,6 +65,7 @@
         {
             var optionsMenuBuilder = new OptionsMenuBuilder<T>();
             RegisterModOptions(optionsMenuBuilder);
+            optionsMenuBuilder.ConfigFileMetadata.Registered = true;
 
             var menuAttribute = typeof(T).GetCustomAttribute<MenuAttribute>(true)
                 ?? new MenuAttribute(optionsMenuBuilder.Name);


### PR DESCRIPTION
## Changes made in this pull request
  - Defers all events for `ConfigFile`s making use of the `OptionsMenuBuilder` until the options menu has been successfully registered and the `ConfigFile` has been returned to the API consumer.

This is implemented by way of checking whether we have yet marked the options menu as being registered, and if not, wait until the first frame where it has been marked as registered, using UnityEngine's coroutines.

This enables consistency in all events - the API consumer can be sure that the `ConfigFile` instance has been passed back to them for use.

## Builds de044d1
### Subnautica
[Stable](https://github.com/SubnauticaModding/SMLHelper/files/6790818/SMLHelper_SN.STABLE.zip)
[Experimental](https://github.com/SubnauticaModding/SMLHelper/files/6790819/SMLHelper_SN.EXP.zip)

### Below Zero
[Stable](https://github.com/SubnauticaModding/SMLHelper/files/6790821/SMLHelper_BZ.STABLE.zip)
[Experimental](https://github.com/SubnauticaModding/SMLHelper/files/6790822/SMLHelper_BZ.EXP.zip)