### PR TITLE
Add a base `JsonFile` implementation for extension, as well as a `SaveDataCache` extension of `JsonFile` for working with per-mod-per-saveslot cached data

### DIFF
--- a/Example mod/Example mod.csproj
+++ b/Example mod/Example mod.csproj
@@ -72,6 +72,14 @@
       <HintPath>$(Dependencies)\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Assembly-CSharp-firstpass_publicized">
+      <HintPath>$(Dependencies)\Assembly-CSharp-firstpass_publicized.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp_publicized">
+      <HintPath>$(Dependencies)\Assembly-CSharp_publicized.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="QModInstaller">
       <HintPath>$(Dependencies)\QModInstaller.dll</HintPath>
       <Private>False</Private>

--- a/Example mod/Mod.cs
+++ b/Example mod/Mod.cs
@@ -42,9 +42,9 @@ namespace SMLHelper.V2.Examples
             // Simply display the recorded player position whenever the save data is loaded
             saveData.OnFinishedLoading += (object sender, JsonFileEventArgs e) =>
             {
-                SaveData data = e.Instance as SaveData; // e.Instance is a JsonFile, which SaveDataCache derives from, 
-                                                        // so we can use polymorphism to convert the JsonFile back into a 
-                                                        // SaveData instance, and access its members, such as PlayerPosition
+                SaveData data = e.Instance as SaveData; // e.Instance is the instance of your SaveData stored as a JsonFile.
+                                                        // We can use polymorphism to convert it back into a SaveData
+                                                        // instance, and access its members, such as PlayerPosition.
 
                 Logger.Log(Logger.Level.Info,
                            $"loaded player position from save slot: {data.PlayerPosition}",

--- a/Example mod/Mod.cs
+++ b/Example mod/Mod.cs
@@ -26,46 +26,44 @@ namespace SMLHelper.V2.Examples
             public Vector3 PlayerPosition { get; set; }
         }
 
-        /// <summary>
-        /// Here, we are setting up a instance of <see cref="Config"/>, which will automatically generate an options menu using
-        /// Attributes. The values in this instance will be updated whenever the user changes the corresponding option in the menu.
-        /// </summary>
-        internal static Config Config { get; } = OptionsPanelHandler.Main.RegisterModOptions<Config>();
-
-        /// <summary>
-        /// In a similar manner to the above, here we set up an instance of <see cref="SaveData"/>, which will automatically
-        /// be saved and loaded to and from disk appropriately. 
-        /// The values in this instance will be updated automatically whenever the user switches between save slots.
-        /// </summary>
-        internal static SaveData MySaveData { get; } = SaveDataHandler.Main.RegisterSaveDataCache<SaveData>();
-
         [QModPatch]
         public static void Patch()
         {
+            /// Here, we are setting up a instance of <see cref="Config"/>, which will automatically generate an 
+            /// options menu using Attributes. The values in this instance will be updated whenever the user changes 
+            /// the corresponding option in the menu.
+            Config config = OptionsPanelHandler.Main.RegisterModOptions<Config>();
+
+            /// In a similar manner to the above, here we set up an instance of <see cref="SaveData"/>, which will 
+            /// automatically be saved and loaded to and from disk appropriately.
+            /// The values in this instance will be updated automatically whenever the user switches between save slots.
+            SaveData saveData = SaveDataHandler.Main.RegisterSaveDataCache<SaveData>();
+
             // Simply display the recorded player position whenever the save data is loaded
-            MySaveData.OnFinishedLoading += (object sender, JsonFileEventArgs e) =>
+            saveData.OnFinishedLoading += (object sender, JsonFileEventArgs e) =>
             {
                 SaveData data = e.Instance as SaveData; // e.Instance is a JsonFile, which SaveDataCache derives from, 
                                                         // so we can use polymorphism to convert the JsonFile back into a 
                                                         // SaveData instance, and access its members, such as PlayerPosition
 
-                Logger.Log(Logger.Level.Info, 
-                           $"loaded player position from save slot: {data.PlayerPosition}", 
+                Logger.Log(Logger.Level.Info,
+                           $"loaded player position from save slot: {data.PlayerPosition}",
                            showOnScreen: true);
             };
 
             // Update the player position before saving it
-            MySaveData.OnStartedSaving += (object sender, JsonFileEventArgs e) =>
+            saveData.OnStartedSaving += (object sender, JsonFileEventArgs e) =>
             {
-                MySaveData.PlayerPosition = Player.main.transform.position;
+                SaveData data = e.Instance as SaveData;
+                data.PlayerPosition = Player.main.transform.position;
             };
 
             // Simply display the position we recorded to the save file whenever the save data it is saved
-            MySaveData.OnFinishedSaving += (object sender, JsonFileEventArgs e) =>
+            saveData.OnFinishedSaving += (object sender, JsonFileEventArgs e) =>
             {
                 SaveData data = e.Instance as SaveData;
-                Logger.Log(Logger.Level.Info, 
-                           $"saved player position to save slot: {data.PlayerPosition}", 
+                Logger.Log(Logger.Level.Info,
+                           $"saved player position to save slot: {data.PlayerPosition}",
                            showOnScreen: true);
             };
 

--- a/Example mod/Mod.cs
+++ b/Example mod/Mod.cs
@@ -4,6 +4,7 @@ using SMLHelper.V2.Commands;
 using SMLHelper.V2.Handlers;
 using SMLHelper.V2.Interfaces;
 using SMLHelper.V2.Json;
+using SMLHelper.V2.Json.Attributes;
 using SMLHelper.V2.Options;
 using SMLHelper.V2.Options.Attributes;
 using System;
@@ -16,15 +17,34 @@ namespace SMLHelper.V2.Examples
     [QModCore]
     public static class ExampleMod
     {
+        [HarmonyPatch(typeof(Player), nameof(Player.Update))]
+        public static class PlayerUpdatePatch
+        {
+            public static void Postfix()
+            {
+                MySaveData.PlayerPosition = MainCamera.camera.transform.position;
+            }
+        }
+
+        [FileName("player_position")]
+        internal class SaveData : SaveDataCache
+        {
+            public Vector3 PlayerPosition { get; set; } = Vector3.zero;
+        }
+
         /// <summary>
         /// Here, we are setting up a instance of <see cref="Config"/>, which will automatically generate an options menu using
         /// Attributes. The values in this instance will be updated whenever the user changes the corresponding option in the menu.
         /// </summary>
         internal static Config Config { get; } = OptionsPanelHandler.Main.RegisterModOptions<Config>();
 
+        internal static SaveData MySaveData { get; } = SaveDataHandler.Main.RegisterSaveDataCache<SaveData>();
+
         [QModPatch]
         public static void Patch()
         {
+            Harmony.CreateAndPatchAll(System.Reflection.Assembly.GetExecutingAssembly());
+
             Logger.Log(Logger.Level.Info, "Patched successfully!");
 
             /// Here we are registering a console command by use of a delegate. The delegate will respond to the "delegatecommand"

--- a/Example mod/Mod.cs
+++ b/Example mod/Mod.cs
@@ -45,11 +45,13 @@ namespace SMLHelper.V2.Examples
             // Simply display the recorded player position whenever the save data is loaded
             MySaveData.OnFinishedLoading += (object sender, JsonFileEventArgs e) =>
             {
-                SaveData data = e.Instance as SaveData; // e.Instance is a JsonFile, which SaveDataCache derives from, so we can use
-                                                        // polymorphism to convert the JsonFile back into a SaveData instance,
-                                                        // and access its members, such as PlayerPosition
+                SaveData data = e.Instance as SaveData; // e.Instance is a JsonFile, which SaveDataCache derives from, 
+                                                        // so we can use polymorphism to convert the JsonFile back into a 
+                                                        // SaveData instance, and access its members, such as PlayerPosition
 
-                Logger.Log(Logger.Level.Info, $"loaded player position from save slot: {data.PlayerPosition}", showOnScreen: true);
+                Logger.Log(Logger.Level.Info, 
+                           $"loaded player position from save slot: {data.PlayerPosition}", 
+                           showOnScreen: true);
             };
 
             // Update the player position before saving it
@@ -62,7 +64,9 @@ namespace SMLHelper.V2.Examples
             MySaveData.OnFinishedSaving += (object sender, JsonFileEventArgs e) =>
             {
                 SaveData data = e.Instance as SaveData;
-                Logger.Log(Logger.Level.Info, $"saved player position to save slot: {data.PlayerPosition}", showOnScreen: true);
+                Logger.Log(Logger.Level.Info, 
+                           $"saved player position to save slot: {data.PlayerPosition}", 
+                           showOnScreen: true);
             };
 
             /// Here we are registering a console command by use of a delegate. The delegate will respond to the "delegatecommand"

--- a/Example mod/mod.json
+++ b/Example mod/mod.json
@@ -7,5 +7,6 @@
   "AssemblyName": "Example mod.dll",
   "VersionDependencies": {
     "SMLHelper": "2.10.0"
-  }
+  },
+  "Game": "Both"
 }

--- a/Example mod/mod.json
+++ b/Example mod/mod.json
@@ -2,11 +2,11 @@
   "Id": "SMLHelperExampleMod",
   "DisplayName": "Example Mod For SMLHelper",
   "Author": "The SMLHelper Dev Team",
-  "Version": "2.10.0",
+  "Version": "2.10.1",
   "Enable": true,
   "AssemblyName": "Example mod.dll",
   "VersionDependencies": {
-    "SMLHelper": "2.10.0"
+    "SMLHelper": "2.10.1"
   },
   "Game": "Both"
 }

--- a/SMLHelper/Handlers/IngameMenuHandler.cs
+++ b/SMLHelper/Handlers/IngameMenuHandler.cs
@@ -26,6 +26,15 @@
         }
 
         /// <summary>
+        /// Registers a simple <see cref="Action"/> method to invoke whenever the player loads a saved game via the in game menu.
+        /// </summary>
+        /// <param name="onLoadAction">The method to invoke.</param>
+        public static void RegisterOnLoadEvent(Action onLoadAction)
+        {
+            Main.RegisterOnLoadEvent(onLoadAction);
+        }
+
+        /// <summary>
         /// Registers a simple <see cref="Action"/> method to invoke whenever the player quits the game via the in game menu.
         /// </summary>
         /// <param name="onQuitAction">The method to invoke.</param>
@@ -42,6 +51,16 @@
         public static void UnregisterOnSaveEvent(Action onSaveAction)
         {
             Main.UnregisterOnSaveEvent(onSaveAction);
+        }
+
+        /// <summary>
+        /// Removes a method previously added through <see cref="RegisterOnLoadEvent(Action)"/> so it is no longer invoked when loading the game.<para/>
+        /// If you plan on using this, do not register an anonymous method.
+        /// </summary>
+        /// <param name="onLoadAction">The method invoked.</param>
+        public static void UnregisterOnLoadEvent(Action onLoadAction)
+        {
+            Main.UnregisterOnLoadEvent(onLoadAction);
         }
 
         /// <summary>
@@ -64,6 +83,15 @@
         }
 
         /// <summary>
+        /// Registers a simple <see cref="Action"/> method to invoke the <c>first time</c> the player loads a saved game via the in game menu.
+        /// </summary>
+        /// <param name="onLoadAction">The method to invoke. This action will not be invoked a second time.</param>
+        public static void RegisterOneTimeUseOnLoadEvent(Action onLoadAction)
+        {
+            Main.RegisterOneTimeUseOnLoadEvent(onLoadAction);
+        }
+
+        /// <summary>
         /// Registers a simple <see cref="Action"/> method to invoke the <c>first time</c> the player quits the game via the in game menu.
         /// </summary>
         /// <param name="onQuitAction">The method to invoke. This action will not be invoked a second time.</param>
@@ -79,6 +107,11 @@
         void IIngameMenuHandler.RegisterOnSaveEvent(Action onSaveAction)
         {
             IngameMenuPatcher.OnSaveEvents += onSaveAction;
+        }
+
+        void IIngameMenuHandler.RegisterOnLoadEvent(Action onLoadAction)
+        {
+            IngameMenuPatcher.OnLoadEvents += onLoadAction;
         }
 
         /// <summary>
@@ -100,6 +133,11 @@
             IngameMenuPatcher.OnSaveEvents -= onSaveAction;
         }
 
+        void IIngameMenuHandler.UnregisterOnLoadEvent(Action onLoadAction)
+        {
+            IngameMenuPatcher.OnLoadEvents -= onLoadAction;
+        }
+
         /// <summary>
         /// Removes a method previously added through <see cref="RegisterOnSaveEvent(Action)"/> so it is no longer invoked when quiting the game.<para/>
         /// If you plan on using this, do not register an anonymous method.
@@ -117,6 +155,11 @@
         void IIngameMenuHandler.RegisterOneTimeUseOnSaveEvent(Action onSaveAction)
         {
             IngameMenuPatcher.AddOneTimeUseSaveEvent(onSaveAction);
+        }
+
+        void IIngameMenuHandler.RegisterOneTimeUseOnLoadEvent(Action onLoadAction)
+        {
+            IngameMenuPatcher.AddOneTimeUseLoadEvent(onLoadAction);
         }
 
         /// <summary>

--- a/SMLHelper/Handlers/SaveDataHandler.cs
+++ b/SMLHelper/Handlers/SaveDataHandler.cs
@@ -22,7 +22,7 @@
         {
             T cache = new();
 
-            IngameMenuHandler.Main.RegisterOnLoadEvent(() => cache.Load(false));
+            IngameMenuHandler.Main.RegisterOnLoadEvent(() => cache.Load());
             IngameMenuHandler.Main.RegisterOnSaveEvent(() => cache.Save());
 
             return cache;

--- a/SMLHelper/Handlers/SaveDataHandler.cs
+++ b/SMLHelper/Handlers/SaveDataHandler.cs
@@ -1,0 +1,31 @@
+﻿namespace SMLHelper.V2.Handlers
+{
+    using Interfaces;
+    using Json;
+
+    /// <summary>
+    /// A handler class for registering your <see cref="SaveDataCache"/>.
+    /// </summary>
+    public class SaveDataHandler : ISaveDataHandler
+    {
+        /// <summary>
+        /// Main entry point for all calls to this handler.
+        /// </summary>
+        public static ISaveDataHandler Main { get; } = new SaveDataHandler();
+
+        private SaveDataHandler()
+        {
+            // Hide Constructor
+        }
+
+        T ISaveDataHandler.RegisterSaveDataCache<T>()
+        {
+            T cache = new();
+
+            IngameMenuHandler.Main.RegisterOnLoadEvent(() => cache.Load(false));
+            IngameMenuHandler.Main.RegisterOnSaveEvent(() => cache.Save());
+
+            return cache;
+        }
+    }
+}

--- a/SMLHelper/Interfaces/IIngameMenuHandler.cs
+++ b/SMLHelper/Interfaces/IIngameMenuHandler.cs
@@ -14,6 +14,12 @@
         void RegisterOnSaveEvent(Action onSaveAction);
 
         /// <summary>
+        /// Registers a simple <see cref="Action"/> method to invoke whenever the player loads a saved game via the in game menu.
+        /// </summary>
+        /// <param name="onLoadAction">The method to invoke.</param>
+        void RegisterOnLoadEvent(Action onLoadAction);
+
+        /// <summary>
         /// Registers a simple <see cref="Action"/> method to invoke whenever the player quits the game via the in game menu.
         /// </summary>
         /// <param name="onQuitAction">The method to invoke.</param>
@@ -27,6 +33,13 @@
         void UnregisterOnSaveEvent(Action onSaveAction);
 
         /// <summary>
+        /// Removes a method previously added through <see cref="RegisterOnLoadEvent(Action)"/> so it is no longer invoked when loading the game.<para/>
+        /// If you plan on using this, do not register an anonymous method.
+        /// </summary>
+        /// <param name="onLoadAction">The method invoked.</param>
+        void UnregisterOnLoadEvent(Action onLoadAction);
+
+        /// <summary>
         /// Removes a method previously added through <see cref="RegisterOnQuitEvent(Action)"/> so it is no longer invoked when quiting the game.<para/>
         /// If you plan on using this, do not register an anonymous method.
         /// </summary>
@@ -38,6 +51,12 @@
         /// </summary>
         /// <param name="onSaveAction">The method to invoke. This action will not be invoked a second time.</param>
         void RegisterOneTimeUseOnSaveEvent(Action onSaveAction);
+
+        /// <summary>
+        /// Registers a simple <see cref="Action"/> method to invoke the <c>first time</c> the player loads a saved game via the in game menu.
+        /// </summary>
+        /// <param name="onLoadAction">The method to invoke. This action will not be invoked a second time.</param>
+        void RegisterOneTimeUseOnLoadEvent(Action onLoadAction);
 
         /// <summary>
         /// Registers a simple <see cref="Action"/> method to invoke the <c>first time</c> the player quits the game via the in game menu.

--- a/SMLHelper/Interfaces/ISaveDataHandler.cs
+++ b/SMLHelper/Interfaces/ISaveDataHandler.cs
@@ -12,7 +12,7 @@
         /// </summary>
         /// <typeparam name="T">A class derived from <see cref="SaveDataCache"/> to hold your save data.</typeparam>
         /// <returns>An instance of the <typeparamref name="T"/> : <see cref="SaveDataCache"/> with values loaded
-        /// from the json file on disk.</returns>
+        /// from the json file on disk whenever a save slot is loaded.</returns>
         T RegisterSaveDataCache<T>() where T : SaveDataCache, new();
     }
 }

--- a/SMLHelper/Interfaces/ISaveDataHandler.cs
+++ b/SMLHelper/Interfaces/ISaveDataHandler.cs
@@ -1,0 +1,18 @@
+﻿namespace SMLHelper.V2.Interfaces
+{
+    using Json;
+
+    /// <summary>
+    /// A handler class for registering your <see cref="SaveDataCache"/>.
+    /// </summary>
+    public interface ISaveDataHandler
+    {
+        /// <summary>
+        /// Registers your <see cref="SaveDataCache"/> to be automatically loaded and saved whenever the game is.
+        /// </summary>
+        /// <typeparam name="T">A class derived from <see cref="SaveDataCache"/> to hold your save data.</typeparam>
+        /// <returns>An instance of the <typeparamref name="T"/> : <see cref="SaveDataCache"/> with values loaded
+        /// from the json file on disk.</returns>
+        T RegisterSaveDataCache<T>() where T : SaveDataCache, new();
+    }
+}

--- a/SMLHelper/Json/Attributes/FileNameAttribute.cs
+++ b/SMLHelper/Json/Attributes/FileNameAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace SMLHelper.V2.Json.Attributes
+{
+    /// <summary>
+    /// Attribute used to specify a file name for use with a <see cref="JsonFile"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class FileNameAttribute : Attribute
+    {
+        /// <summary>
+        /// The filename.
+        /// </summary>
+        public string FileName { get; }
+
+        /// <summary>
+        /// Used to specify the file name for a <see cref="JsonFile"/>.
+        /// </summary>
+        /// <param name="fileName"></param>
+        public FileNameAttribute(string fileName)
+        {
+            FileName = fileName;
+        }
+    }
+}

--- a/SMLHelper/Json/ConfigFile.cs
+++ b/SMLHelper/Json/ConfigFile.cs
@@ -1,19 +1,20 @@
-﻿namespace SMLHelper.V2.Json
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Linq;
+#if SUBNAUTICA_STABLE
+using Oculus.Newtonsoft.Json;
+using Oculus.Newtonsoft.Json.Converters;
+#else
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+#endif
+
+namespace SMLHelper.V2.Json
 {
     using Converters;
     using ExtensionMethods;
     using Interfaces;
-    using System;
-    using System.IO;
-    using System.Reflection;
-    using System.Linq;
-#if SUBNAUTICA_STABLE
-    using Oculus.Newtonsoft.Json;
-    using Oculus.Newtonsoft.Json.Converters;
-#else
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
-#endif
 
     /// <summary>
     /// A simple implementation of <see cref="IJsonFile"/> for use with config files.
@@ -163,25 +164,5 @@
         public void SaveWithConverters(params JsonConverter[] jsonConverters)
             => this.SaveJson(JsonFilePath,
                 AlwaysIncludedJsonConverters.Concat(jsonConverters).Distinct().ToArray());
-    }
-
-    /// <summary>
-    /// Contains basic information for a <see cref="ConfigFile"/> event.
-    /// </summary>
-    public class ConfigFileEventArgs : EventArgs
-    {
-        /// <summary>
-        /// The instance of the <see cref="ConfigFile"/> this event pertains to.
-        /// </summary>
-        public ConfigFile Instance { get; }
-
-        /// <summary>
-        /// Instantiates a new <see cref="ConfigFileEventArgs"/>.
-        /// </summary>
-        /// <param name="instance">The <see cref="ConfigFile"/> instance the event pertains to.</param>
-        public ConfigFileEventArgs(ConfigFile instance)
-        {
-            Instance = instance;
-        }
     }
 }

--- a/SMLHelper/Json/ConfigFileEventArgs.cs
+++ b/SMLHelper/Json/ConfigFileEventArgs.cs
@@ -3,7 +3,7 @@
 namespace SMLHelper.V2.Json
 {
     /// <summary>
-    /// Contains basic information for a <see cref="JsonFile"/> event.
+    /// Contains basic information for a <see cref="ConfigFile"/> event.
     /// </summary>
     public class ConfigFileEventArgs : EventArgs
     {

--- a/SMLHelper/Json/ConfigFileEventArgs.cs
+++ b/SMLHelper/Json/ConfigFileEventArgs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace SMLHelper.V2.Json
+{
+    /// <summary>
+    /// Contains basic information for a <see cref="JsonFile"/> event.
+    /// </summary>
+    public class ConfigFileEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The instance of the <see cref="ConfigFile"/> this event pertains to.
+        /// </summary>
+        public ConfigFile Instance { get; }
+
+        /// <summary>
+        /// Instantiates a new <see cref="ConfigFileEventArgs"/>.
+        /// </summary>
+        /// <param name="instance">The <see cref="ConfigFile"/> instance the event pertains to.</param>
+        public ConfigFileEventArgs(ConfigFile instance)
+        {
+            Instance = instance;
+        }
+    }
+}

--- a/SMLHelper/Json/JsonFile.cs
+++ b/SMLHelper/Json/JsonFile.cs
@@ -27,10 +27,12 @@ namespace SMLHelper.V2.Json
 
         [JsonIgnore]
         private static readonly JsonConverter[] alwaysIncludedJsonConverters = new JsonConverter[] {
-            new KeyCodeConverter(),
             new FloatConverter(),
+            new KeyCodeConverter(),
             new StringEnumConverter(),
-            new VersionConverter()
+            new VersionConverter(),
+            new Vector3Converter(),
+            new QuaternionConverter()
         };
 
         /// <summary>

--- a/SMLHelper/Json/JsonFile.cs
+++ b/SMLHelper/Json/JsonFile.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Linq;
+#if SUBNAUTICA_STABLE
+using Oculus.Newtonsoft.Json;
+using Oculus.Newtonsoft.Json.Converters;
+#else
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+#endif
+
+namespace SMLHelper.V2.Json
+{
+    using Converters;
+    using ExtensionMethods;
+    using Interfaces;
+
+    /// <summary>
+    /// A simple abstract implementation of <see cref="IJsonFile"/>.
+    /// </summary>
+    public abstract class JsonFile : IJsonFile
+    {
+        /// <summary>
+        /// The file path at which the JSON file is accessible for reading and writing.
+        /// </summary>
+        public abstract string JsonFilePath { get; }
+
+        [JsonIgnore]
+        private static readonly JsonConverter[] alwaysIncludedJsonConverters = new JsonConverter[] {
+            new KeyCodeConverter(),
+            new FloatConverter(),
+            new StringEnumConverter(),
+            new VersionConverter()
+        };
+
+        /// <summary>
+        /// The <see cref="JsonConverter"/>s that should always be used when reading/writing JSON data.
+        /// </summary>
+        /// <seealso cref="alwaysIncludedJsonConverters"/>
+        public virtual JsonConverter[] AlwaysIncludedJsonConverters => alwaysIncludedJsonConverters;
+
+        /// <summary>
+        /// An event that is invoked whenever the <see cref="JsonFile"/> is about to load data from disk.
+        /// </summary>
+        [JsonIgnore]
+        public EventHandler<JsonFileEventArgs> OnStartedLoading;
+        /// <summary>
+        /// An event that is invoked whenever the <see cref="JsonFile"/> has finished loading data from disk.
+        /// </summary>
+        [JsonIgnore]
+        public EventHandler<JsonFileEventArgs> OnFinishedLoading;
+
+        /// <summary>
+        /// An event that is invoked whenever the <see cref="JsonFile"/> is about to save data to disk.
+        /// </summary>
+        [JsonIgnore]
+        public EventHandler<JsonFileEventArgs> OnStartedSaving;
+        /// <summary>
+        /// An event that is invoked whenever the <see cref="JsonFile"/> has finished saving data to disk.
+        /// </summary>
+        [JsonIgnore]
+        public EventHandler<JsonFileEventArgs> OnFinishedSaving;
+
+        /// <summary>
+        /// Loads the JSON properties from the file on disk into the <see cref="JsonFile"/>.
+        /// </summary>
+        /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
+        /// already exist.</param>
+        /// <seealso cref="Save()"/>
+        /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
+        public virtual void Load(bool createFileIfNotExist = true)
+        {
+            var e = new JsonFileEventArgs(this);
+            OnStartedLoading?.Invoke(this, e);
+            this.LoadJson(JsonFilePath, createFileIfNotExist, AlwaysIncludedJsonConverters.Distinct().ToArray());
+            OnFinishedLoading?.Invoke(this, e);
+        }
+
+        /// <summary>
+        /// Saves the current fields and properties of the <see cref="JsonFile"/> as JSON properties to the file on disk.
+        /// </summary>
+        /// <seealso cref="Load(bool)"/>
+        /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
+        public virtual void Save()
+        {
+            var e = new JsonFileEventArgs(this);
+            OnStartedSaving?.Invoke(this, e);
+            this.SaveJson(JsonFilePath, AlwaysIncludedJsonConverters.Distinct().ToArray());
+            OnFinishedSaving?.Invoke(this, e);
+        }
+
+        /// <summary>
+        /// Loads the JSON properties from the file on disk into the <see cref="JsonFile"/>.
+        /// </summary>
+        /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
+        /// already exist.</param>
+        /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for serialization.
+        /// The <see cref="AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
+        /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
+        /// <seealso cref="Load(bool)"/>
+        public virtual void LoadWithConverters(bool createFileIfNotExist = true, params JsonConverter[] jsonConverters)
+            => this.LoadJson(JsonFilePath, true,
+                AlwaysIncludedJsonConverters.Concat(jsonConverters).Distinct().ToArray());
+
+        /// <summary>
+        /// Saves the current fields and properties of the <see cref="JsonFile"/> as JSON properties to the file on disk.
+        /// </summary>
+        /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for deserialization.
+        /// The <see cref="AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
+        /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
+        /// <seealso cref="Save"/>
+        public virtual void SaveWithConverters(params JsonConverter[] jsonConverters)
+            => this.SaveJson(JsonFilePath,
+                AlwaysIncludedJsonConverters.Concat(jsonConverters).Distinct().ToArray());
+    }
+}

--- a/SMLHelper/Json/JsonFile.cs
+++ b/SMLHelper/Json/JsonFile.cs
@@ -22,6 +22,7 @@ namespace SMLHelper.V2.Json
         /// <summary>
         /// The file path at which the JSON file is accessible for reading and writing.
         /// </summary>
+        [JsonIgnore]
         public abstract string JsonFilePath { get; }
 
         [JsonIgnore]

--- a/SMLHelper/Json/JsonFileEventArgs.cs
+++ b/SMLHelper/Json/JsonFileEventArgs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace SMLHelper.V2.Json
+{
+    /// <summary>
+    /// Contains basic information for a <see cref="JsonFile"/> event.
+    /// </summary>
+    public class JsonFileEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The instance of the <see cref="JsonFile"/> this event pertains to.
+        /// </summary>
+        public JsonFile Instance { get; }
+
+        /// <summary>
+        /// Instantiates a new <see cref="JsonFileEventArgs"/>.
+        /// </summary>
+        /// <param name="instance">The <see cref="JsonFile"/> instance the event pertains to.</param>
+        public JsonFileEventArgs(JsonFile instance)
+        {
+            Instance = instance;
+        }
+    }
+}

--- a/SMLHelper/Json/SaveDataCache.cs
+++ b/SMLHelper/Json/SaveDataCache.cs
@@ -1,0 +1,147 @@
+﻿using QModManager.API;
+using System;
+using System.IO;
+using System.Reflection;
+using System.Linq;
+#if SUBNAUTICA_STABLE
+using Oculus.Newtonsoft.Json;
+#else
+using Newtonsoft.Json;
+#endif
+
+namespace SMLHelper.V2.Json
+{
+    using Attributes;
+    using Converters;
+    using Interfaces;
+
+    /// <summary>
+    /// An abstract implementation of <see cref="IJsonFile"/> intended for use with caching per-save data.
+    /// </summary>
+    public abstract class SaveDataCache : JsonFile
+    {
+        private UserStoragePC userStorage;
+        private UserStoragePC UserStorage => userStorage ??= PlatformUtils.main.GetUserStorage() as UserStoragePC;
+        private string SaveSlot => SaveLoadManager.main.GetCurrentSlot();
+        private string QModId { get; init; }
+
+        private static readonly JsonConverter[] alwaysIncludedJsonConverters = new JsonConverter[]
+        {
+            new Vector3Converter(), new QuaternionConverter()
+        };
+
+        private bool InGame => SaveSlot != "test";
+
+        private string jsonFileName = null;
+        private string JsonFileName => jsonFileName ??= GetType().GetCustomAttribute<FileNameAttribute>() switch
+        {
+            FileNameAttribute fileNameAttribute => fileNameAttribute.FileName,
+            _ => QModId
+        };
+
+        /// <summary>
+        /// The <see cref="JsonConverter"/>s that should always be used when reading/writing JSON data.
+        /// </summary>
+        /// <seealso cref="alwaysIncludedJsonConverters"/>
+        public override JsonConverter[] AlwaysIncludedJsonConverters
+            => base.AlwaysIncludedJsonConverters.Concat(alwaysIncludedJsonConverters).ToArray();
+
+        /// <summary>
+        /// The file path at which the JSON file is accessible for reading and writing.
+        /// </summary>
+        public override string JsonFilePath => Path.Combine(UserStorage.savePath, SaveSlot, QModId, $"{JsonFileName}.json");
+
+        /// <summary>
+        /// Creates a new instance of <see cref="SaveDataCache"/>, parsing the file name from <see cref="FileNameAttribute"/>
+        /// if declared, or with default values otherwise.
+        /// </summary>
+        public SaveDataCache()
+        {
+            QModId = QModServices.Main.FindModByAssembly(GetType().Assembly).Id;
+        }
+
+        /// <summary>
+        /// Loads the JSON properties from the file on disk into the <see cref="SaveDataCache"/>.
+        /// </summary>
+        /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
+        /// already exist.</param>
+        /// <seealso cref="Save()"/>
+        /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
+        /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>
+        public override void Load(bool createFileIfNotExist = true)
+        {
+            if (InGame)
+            {
+                base.Load(createFileIfNotExist);
+                Logger.Log($"[{QModId}] Loaded save data from {JsonFileName}.json");
+            }
+            else
+            {
+                throw new InvalidOperationException($"[{QModId}] Cannot load save data when not in game!");
+            }
+        }
+
+        /// <summary>
+        /// Saves the current fields and properties of the <see cref="SaveDataCache"/> as JSON properties to the file on disk.
+        /// </summary>
+        /// <seealso cref="Load(bool)"/>
+        /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
+        /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>
+        public override void Save()
+        {
+            if (InGame)
+            {
+                base.Save();
+                Logger.Log($"[{QModId}] Saved save data to {JsonFileName}.json");
+            }
+            else
+            {
+                throw new InvalidOperationException($"[{QModId}] Cannot save save data when not in game!");
+            }
+        }
+
+        /// <summary>
+        /// Loads the JSON properties from the file on disk into the <see cref="SaveDataCache"/>.
+        /// </summary>
+        /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
+        /// already exist.</param>
+        /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for serialization.
+        /// The <see cref="AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
+        /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
+        /// <seealso cref="Load(bool)"/>
+        /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>
+        public override void LoadWithConverters(bool createFileIfNotExist = true, params JsonConverter[] jsonConverters)
+        {
+            if (InGame)
+            {
+                base.LoadWithConverters(createFileIfNotExist, jsonConverters);
+                Logger.Log($"[{QModId}] Loaded save data from {JsonFileName}.json");
+            }
+            else
+            {
+                throw new InvalidOperationException($"[{QModId}] Cannot load save data when not in game!");
+            }
+        }
+
+        /// <summary>
+        /// Saves the current fields and properties of the <see cref="SaveDataCache"/> as JSON properties to the file on disk.
+        /// </summary>
+        /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for deserialization.
+        /// The <see cref="AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
+        /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
+        /// <seealso cref="Save"/>
+        /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>
+        public override void SaveWithConverters(params JsonConverter[] jsonConverters)
+        {
+            if (InGame)
+            {
+                base.SaveWithConverters(jsonConverters);
+                Logger.Log($"[{QModId}] Saved save data to {JsonFileName}.json");
+            }
+            else
+            {
+                throw new InvalidOperationException($"[{QModId}] Cannot save save data when not in game!");
+            }
+        }
+    }
+}

--- a/SMLHelper/Json/SaveDataCache.cs
+++ b/SMLHelper/Json/SaveDataCache.cs
@@ -64,11 +64,12 @@ namespace SMLHelper.V2.Json
         /// Loads the JSON properties from the file on disk into the <see cref="SaveDataCache"/>.
         /// </summary>
         /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
-        /// already exist.</param>
+        /// already exist.<br/>
+        /// Don't set this to <see langword="true"/> unless you know exactly what you're doing.</param>
         /// <seealso cref="Save()"/>
         /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
         /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>
-        public override void Load(bool createFileIfNotExist = true)
+        public override void Load(bool createFileIfNotExist = false)
         {
             if (InGame)
             {
@@ -104,13 +105,14 @@ namespace SMLHelper.V2.Json
         /// Loads the JSON properties from the file on disk into the <see cref="SaveDataCache"/>.
         /// </summary>
         /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
-        /// already exist.</param>
+        /// already exist.<br/>
+        /// Don't set this to <see langword="true"/> unless you know exactly what you're doing.</param>
         /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for serialization.
         /// The <see cref="AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
         /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
         /// <seealso cref="Load(bool)"/>
         /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>
-        public override void LoadWithConverters(bool createFileIfNotExist = true, params JsonConverter[] jsonConverters)
+        public override void LoadWithConverters(bool createFileIfNotExist = false, params JsonConverter[] jsonConverters)
         {
             if (InGame)
             {

--- a/SMLHelper/Json/SaveDataCache.cs
+++ b/SMLHelper/Json/SaveDataCache.cs
@@ -22,11 +22,6 @@ namespace SMLHelper.V2.Json
     {
         private string QModId { get; init; }
 
-        private static readonly JsonConverter[] alwaysIncludedJsonConverters = new JsonConverter[]
-        {
-            new Vector3Converter(), new QuaternionConverter()
-        };
-
         private bool InGame => string.IsNullOrWhiteSpace(SaveLoadManager.GetTemporarySavePath());
 
         private string jsonFileName = null;
@@ -35,13 +30,6 @@ namespace SMLHelper.V2.Json
             FileNameAttribute fileNameAttribute => fileNameAttribute.FileName,
             _ => QModId
         };
-
-        /// <summary>
-        /// The <see cref="JsonConverter"/>s that should always be used when reading/writing JSON data.
-        /// </summary>
-        /// <seealso cref="alwaysIncludedJsonConverters"/>
-        public override JsonConverter[] AlwaysIncludedJsonConverters
-            => base.AlwaysIncludedJsonConverters.Concat(alwaysIncludedJsonConverters).ToArray();
 
         /// <summary>
         /// The file path at which the JSON file is accessible for reading and writing.

--- a/SMLHelper/Json/SaveDataCache.cs
+++ b/SMLHelper/Json/SaveDataCache.cs
@@ -2,7 +2,6 @@
 using System;
 using System.IO;
 using System.Reflection;
-using System.Linq;
 #if SUBNAUTICA_STABLE
 using Oculus.Newtonsoft.Json;
 #else
@@ -12,7 +11,6 @@ using Newtonsoft.Json;
 namespace SMLHelper.V2.Json
 {
     using Attributes;
-    using Converters;
     using Interfaces;
 
     /// <summary>
@@ -91,7 +89,7 @@ namespace SMLHelper.V2.Json
         /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
         /// already exist.</param>
         /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for serialization.
-        /// The <see cref="AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
+        /// The <see cref="JsonFile.AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
         /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
         /// <seealso cref="Load(bool)"/>
         /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>
@@ -112,7 +110,7 @@ namespace SMLHelper.V2.Json
         /// Saves the current fields and properties of the <see cref="SaveDataCache"/> as JSON properties to the file on disk.
         /// </summary>
         /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for deserialization.
-        /// The <see cref="AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
+        /// The <see cref="JsonFile.AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
         /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
         /// <seealso cref="Save"/>
         /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>

--- a/SMLHelper/Json/SaveDataCache.cs
+++ b/SMLHelper/Json/SaveDataCache.cs
@@ -20,9 +20,6 @@ namespace SMLHelper.V2.Json
     /// </summary>
     public abstract class SaveDataCache : JsonFile
     {
-        private UserStoragePC userStorage;
-        private UserStoragePC UserStorage => userStorage ??= PlatformUtils.main.GetUserStorage() as UserStoragePC;
-        private string SaveSlot => SaveLoadManager.main.GetCurrentSlot();
         private string QModId { get; init; }
 
         private static readonly JsonConverter[] alwaysIncludedJsonConverters = new JsonConverter[]
@@ -30,7 +27,7 @@ namespace SMLHelper.V2.Json
             new Vector3Converter(), new QuaternionConverter()
         };
 
-        private bool InGame => SaveSlot != "test";
+        private bool InGame => string.IsNullOrWhiteSpace(SaveLoadManager.GetTemporarySavePath());
 
         private string jsonFileName = null;
         private string JsonFileName => jsonFileName ??= GetType().GetCustomAttribute<FileNameAttribute>() switch
@@ -49,7 +46,7 @@ namespace SMLHelper.V2.Json
         /// <summary>
         /// The file path at which the JSON file is accessible for reading and writing.
         /// </summary>
-        public override string JsonFilePath => Path.Combine(UserStorage.savePath, SaveSlot, QModId, $"{JsonFileName}.json");
+        public override string JsonFilePath => Path.Combine(SaveLoadManager.GetTemporarySavePath(), QModId, $"{JsonFileName}.json");
 
         /// <summary>
         /// Creates a new instance of <see cref="SaveDataCache"/>, parsing the file name from <see cref="FileNameAttribute"/>
@@ -64,12 +61,11 @@ namespace SMLHelper.V2.Json
         /// Loads the JSON properties from the file on disk into the <see cref="SaveDataCache"/>.
         /// </summary>
         /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
-        /// already exist.<br/>
-        /// Don't set this to <see langword="true"/> unless you know exactly what you're doing.</param>
+        /// already exist.</param>
         /// <seealso cref="Save()"/>
         /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
         /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>
-        public override void Load(bool createFileIfNotExist = false)
+        public override void Load(bool createFileIfNotExist = true)
         {
             if (InGame)
             {
@@ -105,14 +101,13 @@ namespace SMLHelper.V2.Json
         /// Loads the JSON properties from the file on disk into the <see cref="SaveDataCache"/>.
         /// </summary>
         /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
-        /// already exist.<br/>
-        /// Don't set this to <see langword="true"/> unless you know exactly what you're doing.</param>
+        /// already exist.</param>
         /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for serialization.
         /// The <see cref="AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
         /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
         /// <seealso cref="Load(bool)"/>
         /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>
-        public override void LoadWithConverters(bool createFileIfNotExist = false, params JsonConverter[] jsonConverters)
+        public override void LoadWithConverters(bool createFileIfNotExist = true, params JsonConverter[] jsonConverters)
         {
             if (InGame)
             {

--- a/SMLHelper/Patchers/IngameMenuPatcher.cs
+++ b/SMLHelper/Patchers/IngameMenuPatcher.cs
@@ -7,15 +7,19 @@
     internal class IngameMenuPatcher
     {
         private static readonly List<Action> oneTimeUseOnSaveEvents = new List<Action>();
+        private static readonly List<Action> oneTimeUseOnLoadEvents = new List<Action>();
         private static readonly List<Action> oneTimeUseOnQuitEvents = new List<Action>();
 
         internal static Action OnSaveEvents;
+        internal static Action OnLoadEvents;
         internal static Action OnQuitEvents;
 
         public static void Patch(Harmony harmony)
         {
             harmony.Patch(AccessTools.Method(typeof(IngameMenu), nameof(IngameMenu.SaveGame)),
                 postfix: new HarmonyMethod(AccessTools.Method(typeof(IngameMenuPatcher), nameof(InvokeSaveEvents))));
+            harmony.Patch(AccessTools.Method(typeof(uGUI_SceneLoading), nameof(uGUI_SceneLoading.BeginAsyncSceneLoad)),
+                postfix: new HarmonyMethod(AccessTools.Method(typeof(IngameMenuPatcher), nameof(InvokeLoadEvents))));
             harmony.Patch(AccessTools.Method(typeof(IngameMenu), nameof(IngameMenu.QuitGame)),
                 postfix: new HarmonyMethod(AccessTools.Method(typeof(IngameMenuPatcher), nameof(InvokeQuitEvents))));
         }
@@ -23,6 +27,11 @@
         internal static void AddOneTimeUseSaveEvent(Action onSaveAction)
         {
             oneTimeUseOnSaveEvents.Add(onSaveAction);
+        }
+
+        internal static void AddOneTimeUseLoadEvent(Action onLoadAction)
+        {
+            oneTimeUseOnLoadEvents.Add(onLoadAction);
         }
 
         internal static void AddOneTimeUseQuitEvent(Action onQuitAction)
@@ -40,6 +49,22 @@
                     action.Invoke();
 
                 oneTimeUseOnSaveEvents.Clear();
+            }
+        }
+
+        internal static void InvokeLoadEvents(string sceneName)
+        {
+            if (sceneName == "Main")
+            {
+                OnLoadEvents?.Invoke();
+
+                if (oneTimeUseOnLoadEvents.Count > 0)
+                {
+                    foreach (Action action in oneTimeUseOnLoadEvents)
+                        action.Invoke();
+
+                    oneTimeUseOnLoadEvents.Clear();
+                }
             }
         }
 

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Handlers\CoordinatedSpawnsHandler.cs" />
     <Compile Include="Handlers\CustomSoundHandler.cs" />
     <Compile Include="Handlers\PingHandler.cs" />
+    <Compile Include="Handlers\SaveDataHandler.cs" />
     <Compile Include="Handlers\SurvivalHandler.cs" />
     <Compile Include="Handlers\TechCategoryHandler.cs" />
     <Compile Include="Handlers\TechGroupHandler.cs" />
@@ -163,10 +164,13 @@
     <Compile Include="Interfaces\IModOptionEventAttribute.cs" />
     <Compile Include="Interfaces\IConsoleCommandHandler.cs" />
     <Compile Include="Interfaces\IPingHandler.cs" />
+    <Compile Include="Interfaces\ISaveDataHandler.cs" />
     <Compile Include="Interfaces\ISurvivalHandler.cs" />
     <Compile Include="Interfaces\ITechCategoryHandler.cs" />
     <Compile Include="Interfaces\ITechGroupHandler.cs" />
+    <Compile Include="Json\Attributes\FileNameAttribute.cs" />
     <Compile Include="Json\ConfigFileAttribute.cs" />
+    <Compile Include="Json\ConfigFileEventArgs.cs" />
     <Compile Include="Json\Converters\FloatConverter.cs" />
     <Compile Include="Json\Converters\QuaternionConverter.cs" />
     <Compile Include="Json\Converters\Vector3Converter.cs" />
@@ -212,6 +216,9 @@
     <Compile Include="Interfaces\ITechTypeHandler.cs" />
     <Compile Include="Interfaces\ITechTypeHandlerInternal.cs" />
     <Compile Include="Interfaces\IWorldEntityDatabaseHandler.cs" />
+    <Compile Include="Json\JsonFile.cs" />
+    <Compile Include="Json\JsonFileEventArgs.cs" />
+    <Compile Include="Json\SaveDataCache.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="MonoBehaviours\EntitySpawner.cs" />
     <Compile Include="MonoBehaviours\Fixer.cs" />


### PR DESCRIPTION
## Changes made in this pull request
  - Adds a basic `JsonFile` abstract implementation of `IJsonFile`, to alow easy extension in a similar manner to how `ConfigFile` operates.
  - Adds a base `SaveDataCache` abstract extension of `JsonFile`, which is intended to be used as a per-mod-per-saveslot data cache. Multiple can be used per mod. It automatically generates the file path based on the game's SaveLoadManager.GetTemporaryStoragePath() and the SaveDataCache's defining QMod, i.e.:
  `Subnautica\TempSave\tmp964151\SMLHelperExampleMod\player_position.json`.
  This data will be moved into/out of deep storage as per normal, whenever the game is saved and loaded.
  - Adds a `SaveDataHandler`, which allows an API consumer to easily register a `SaveDataCache` to be automatically loaded and saved when appropriate.
  - To facilitate `SaveDataHandler` auto-loading the `SaveDataCache` files, adds public methods to the `InGameMenuHandler`: `RegisterOnLoadEvent`, `UnregisterOnLoadEvent` and `RegisterOneTimeUseOnLoadEvent` as companions to the methods already provided, which trigger when the game loads into the "Main" scene.
  - Updated `ExampleMod` to show a basic usage of `SaveDataCache`.

## Examples
### `JsonFile`
```cs
public class MyJsonFile : JsonFile
{
    private static IQMod qMod;
    private static IQMod QMod => qMod ??= QModServices.Main.GetMyMod();

    public override string JsonFilePath => Path.Combine(Path.GetDirectoryName(QMod.LoadedAssembly.Location),
                                                        "my_json_file.json");

    public string MyString { get; set; }
}

[QModCore]
public static class Main
{
    [QModPatch]
    public static void Patch()
    {
        MyJsonFile json = new MyJsonFile();
        json.Load();
        json.MyString = "foo";
        json.Save();
    }
}
```

### `SaveDataCache`
```cs
/// <summary>
/// A simple SaveDataCache implementation, intended to save the players current position to disk.
/// </summary>
[FileName("player_position")]
internal class SaveData : SaveDataCache
{
    public Vector3 PlayerPosition { get; set; }
}

[QModCore]
public static class Main
{
    [QModPatch]
    public static void Patch()
    {
        /// Works like ConfigFile - it will be automatically saved/loaded to/from disk appropriately,
        /// with its members updated whenever the user switches between save slots.
        SaveData saveData = SaveDataHandler.Main.RegisterSaveDataCache<SaveData>();

        // Simply display the recorded player position whenever the save data is loaded
        saveData.OnFinishedLoading += (object sender, JsonFileEventArgs e) =>
        {
            SaveData data = e.Instance as SaveData; // e.Instance is the instance of your SaveData stored as a JsonFile.
                                                    // We can use polymorphism to convert it back into a SaveData
                                                    // instance, and access its members, such as PlayerPosition.

            Logger.Log(Logger.Level.Info, 
                       $"loaded player position from save slot: {data.PlayerPosition}", 
                       showOnScreen: true);
        };

        // Update the player position before saving it
        saveData.OnStartedSaving += (object sender, JsonFileEventArgs e) =>
        {
            SaveData data = e.Instance as SaveData;
            data.PlayerPosition = Player.main.transform.position;
        };

        // Simply display the position we recorded to the save file whenever the save data it is saved
        saveData.OnFinishedSaving += (object sender, JsonFileEventArgs e) =>
        {
            SaveData data = e.Instance as SaveData;
            Logger.Log(Logger.Level.Info, 
                       $"saved player position to save slot: {data.PlayerPosition}", 
                       showOnScreen: true);
        };
    }
}
```

`JsonFile` implementations, similar to `ConfigFile`, have public `OnStartedLoading`/`OnFinishedLoading` & `OnStartedSaving`/`OnFinishedSaving` events, and since `SaveDataCache` extends `JsonFile`, you can easily hook up to these events if you need to react to the save/loads and do a bunch of processing, for example spawning in items in the correct locations.

Like with `ConfigFile`, it is entirely possible to use `SaveDataCache` without using the `SaveDataHandler`, but you will be responsible for handling when to save and load the data yourself. 

If no `FileNameAttribute` is provided, the default filename is the QMod's id.

## Builds a3634f5
### Subnautica
#### Stable
[SMLHelper](https://github.com/SubnauticaModding/SMLHelper/files/6795274/SMLHelper_SN.STABLE.zip)
[Example Mod](https://github.com/SubnauticaModding/SMLHelper/files/6795281/SN.STABLE.zip)

#### Experimental
[SMLHelper](https://github.com/SubnauticaModding/SMLHelper/files/6795275/SMLHelper_SN.EXP.zip)
[Example Mod](https://github.com/SubnauticaModding/SMLHelper/files/6795282/SN.EXP.zip)

### Below Zero
#### Stable
[SMLHelper Zero](https://github.com/SubnauticaModding/SMLHelper/files/6795276/SMLHelper_BZ.STABLE.zip)
[Example Mod](https://github.com/SubnauticaModding/SMLHelper/files/6795284/BZ.STABLE.zip)

#### Experimental
[SMLHelper Zero](https://github.com/SubnauticaModding/SMLHelper/files/6795277/SMLHelper_BZ.EXP.zip)
[Example Mod](https://github.com/SubnauticaModding/SMLHelper/files/6795286/BZ.EXP.zip)