### PR TITLE
`CoodinatedSpawnsInitialized.smlhelper` bugfix

### DIFF
--- a/SMLHelper/Patchers/LargeWorldStreamerPatcher.cs
+++ b/SMLHelper/Patchers/LargeWorldStreamerPatcher.cs
@@ -60,19 +60,19 @@ namespace SMLHelper.V2.Patchers
                     spawnInfos.Remove(savedSpawnInfo);
             }
 
-            IngameMenuHandler.RegisterOneTimeUseOnSaveEvent(() => SaveData(file));
+            IngameMenuHandler.RegisterOneTimeUseOnSaveEvent(() => SaveData());
 
             Initialize();
             Logger.Debug("Coordinated Spawns have been initialized in the current save.");
         }
 
-        private static void SaveData(string file)
+        private static void SaveData()
         {
+            var file = Path.Combine(SaveLoadManager.GetTemporarySavePath(), "CoordinatedSpawnsInitialized.smlhelper");
             using var writer = new StreamWriter(file);
             try
             {
                 string data = JsonConvert.SerializeObject(savedSpawnInfos, Formatting.Indented, new Vector3Converter(), new QuaternionConverter());
-                //Logger.Info(data);
                 writer.Write(data);
                 writer.Flush();
                 writer.Close();


### PR DESCRIPTION
## Changes made in this pull request
  - Resolves an issue where the file path would not be correctly updated for the saved file if you backed out to the main menu and loaded the game again, preventing the `CoordinatesSpawnsInitialized.smlhelper` file from being saved.

## Builds a831343
### Subnautica
[Stable](https://github.com/SubnauticaModding/SMLHelper/files/6795381/SMLHelper_SN.STABLE.zip)
[Experimental](https://github.com/SubnauticaModding/SMLHelper/files/6795382/SMLHelper_SN.EXP.zip)

### Below Zero
[Stable](https://github.com/SubnauticaModding/SMLHelper/files/6795383/SMLHelper_BZ.STABLE.zip)
[Experimental](https://github.com/SubnauticaModding/SMLHelper/files/6795385/SMLHelper_BZ.EXP.zip)