### PR TITLE
SMLHelper 2.11

### DIFF
--- a/Example mod/Example mod.csproj
+++ b/Example mod/Example mod.csproj
@@ -72,6 +72,14 @@
       <HintPath>$(Dependencies)\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Assembly-CSharp-firstpass_publicized">
+      <HintPath>$(Dependencies)\Assembly-CSharp-firstpass_publicized.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp_publicized">
+      <HintPath>$(Dependencies)\Assembly-CSharp_publicized.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="QModInstaller">
       <HintPath>$(Dependencies)\QModInstaller.dll</HintPath>
       <Private>False</Private>

--- a/Example mod/Properties/AssemblyInfo.cs
+++ b/Example mod/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.0.0")]
-[assembly: AssemblyFileVersion("2.10.0.0")]
+[assembly: AssemblyVersion("2.10.1.1")]
+[assembly: AssemblyFileVersion("2.10.1.1")]

--- a/Example mod/Properties/AssemblyInfo.cs
+++ b/Example mod/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.1.2")]
-[assembly: AssemblyFileVersion("2.10.1.2")]
+[assembly: AssemblyVersion("2.11.0.0")]
+[assembly: AssemblyFileVersion("2.11.0.0")]

--- a/Example mod/Properties/AssemblyInfo.cs
+++ b/Example mod/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.1.1")]
-[assembly: AssemblyFileVersion("2.10.1.1")]
+[assembly: AssemblyVersion("2.10.1.2")]
+[assembly: AssemblyFileVersion("2.10.1.2")]

--- a/Example mod/mod.json
+++ b/Example mod/mod.json
@@ -2,11 +2,11 @@
   "Id": "SMLHelperExampleMod",
   "DisplayName": "Example Mod For SMLHelper",
   "Author": "The SMLHelper Dev Team",
-  "Version": "2.10.1.1",
+  "Version": "2.10.1.2",
   "Enable": true,
   "AssemblyName": "Example mod.dll",
   "VersionDependencies": {
-    "SMLHelper": "2.10.1"
+    "SMLHelper": "2.10.1.2"
   },
   "Game": "Both"
 }

--- a/Example mod/mod.json
+++ b/Example mod/mod.json
@@ -2,11 +2,11 @@
   "Id": "SMLHelperExampleMod",
   "DisplayName": "Example Mod For SMLHelper",
   "Author": "The SMLHelper Dev Team",
-  "Version": "2.10.1.2",
+  "Version": "2.11",
   "Enable": true,
   "AssemblyName": "Example mod.dll",
   "VersionDependencies": {
-    "SMLHelper": "2.10.1.2"
+    "SMLHelper": "2.11"
   },
   "Game": "Both"
 }

--- a/Example mod/mod.json
+++ b/Example mod/mod.json
@@ -2,10 +2,11 @@
   "Id": "SMLHelperExampleMod",
   "DisplayName": "Example Mod For SMLHelper",
   "Author": "The SMLHelper Dev Team",
-  "Version": "2.10.0",
+  "Version": "2.10.1",
   "Enable": true,
   "AssemblyName": "Example mod.dll",
   "VersionDependencies": {
-    "SMLHelper": "2.10.0"
-  }
+    "SMLHelper": "2.10.1"
+  },
+  "Game": "Both"
 }

--- a/Example mod/mod.json
+++ b/Example mod/mod.json
@@ -2,7 +2,7 @@
   "Id": "SMLHelperExampleMod",
   "DisplayName": "Example Mod For SMLHelper",
   "Author": "The SMLHelper Dev Team",
-  "Version": "2.10.1",
+  "Version": "2.10.1.1",
   "Enable": true,
   "AssemblyName": "Example mod.dll",
   "VersionDependencies": {

--- a/SMLHelper/Handlers/IngameMenuHandler.cs
+++ b/SMLHelper/Handlers/IngameMenuHandler.cs
@@ -26,6 +26,15 @@
         }
 
         /// <summary>
+        /// Registers a simple <see cref="Action"/> method to invoke whenever the player loads a saved game via the in game menu.
+        /// </summary>
+        /// <param name="onLoadAction">The method to invoke.</param>
+        public static void RegisterOnLoadEvent(Action onLoadAction)
+        {
+            Main.RegisterOnLoadEvent(onLoadAction);
+        }
+
+        /// <summary>
         /// Registers a simple <see cref="Action"/> method to invoke whenever the player quits the game via the in game menu.
         /// </summary>
         /// <param name="onQuitAction">The method to invoke.</param>
@@ -42,6 +51,16 @@
         public static void UnregisterOnSaveEvent(Action onSaveAction)
         {
             Main.UnregisterOnSaveEvent(onSaveAction);
+        }
+
+        /// <summary>
+        /// Removes a method previously added through <see cref="RegisterOnLoadEvent(Action)"/> so it is no longer invoked when loading the game.<para/>
+        /// If you plan on using this, do not register an anonymous method.
+        /// </summary>
+        /// <param name="onLoadAction">The method invoked.</param>
+        public static void UnregisterOnLoadEvent(Action onLoadAction)
+        {
+            Main.UnregisterOnLoadEvent(onLoadAction);
         }
 
         /// <summary>
@@ -64,6 +83,15 @@
         }
 
         /// <summary>
+        /// Registers a simple <see cref="Action"/> method to invoke the <c>first time</c> the player loads a saved game via the in game menu.
+        /// </summary>
+        /// <param name="onLoadAction">The method to invoke. This action will not be invoked a second time.</param>
+        public static void RegisterOneTimeUseOnLoadEvent(Action onLoadAction)
+        {
+            Main.RegisterOneTimeUseOnLoadEvent(onLoadAction);
+        }
+
+        /// <summary>
         /// Registers a simple <see cref="Action"/> method to invoke the <c>first time</c> the player quits the game via the in game menu.
         /// </summary>
         /// <param name="onQuitAction">The method to invoke. This action will not be invoked a second time.</param>
@@ -79,6 +107,11 @@
         void IIngameMenuHandler.RegisterOnSaveEvent(Action onSaveAction)
         {
             IngameMenuPatcher.OnSaveEvents += onSaveAction;
+        }
+
+        void IIngameMenuHandler.RegisterOnLoadEvent(Action onLoadAction)
+        {
+            IngameMenuPatcher.OnLoadEvents += onLoadAction;
         }
 
         /// <summary>
@@ -100,6 +133,11 @@
             IngameMenuPatcher.OnSaveEvents -= onSaveAction;
         }
 
+        void IIngameMenuHandler.UnregisterOnLoadEvent(Action onLoadAction)
+        {
+            IngameMenuPatcher.OnLoadEvents -= onLoadAction;
+        }
+
         /// <summary>
         /// Removes a method previously added through <see cref="RegisterOnSaveEvent(Action)"/> so it is no longer invoked when quiting the game.<para/>
         /// If you plan on using this, do not register an anonymous method.
@@ -117,6 +155,11 @@
         void IIngameMenuHandler.RegisterOneTimeUseOnSaveEvent(Action onSaveAction)
         {
             IngameMenuPatcher.AddOneTimeUseSaveEvent(onSaveAction);
+        }
+
+        void IIngameMenuHandler.RegisterOneTimeUseOnLoadEvent(Action onLoadAction)
+        {
+            IngameMenuPatcher.AddOneTimeUseLoadEvent(onLoadAction);
         }
 
         /// <summary>

--- a/SMLHelper/Handlers/OptionsPanelHandler.cs
+++ b/SMLHelper/Handlers/OptionsPanelHandler.cs
@@ -65,6 +65,7 @@
         {
             var optionsMenuBuilder = new OptionsMenuBuilder<T>();
             RegisterModOptions(optionsMenuBuilder);
+            optionsMenuBuilder.ConfigFileMetadata.Registered = true;
 
             var menuAttribute = typeof(T).GetCustomAttribute<MenuAttribute>(true)
                 ?? new MenuAttribute(optionsMenuBuilder.Name);

--- a/SMLHelper/Handlers/SaveDataHandler.cs
+++ b/SMLHelper/Handlers/SaveDataHandler.cs
@@ -1,0 +1,31 @@
+﻿namespace SMLHelper.V2.Handlers
+{
+    using Interfaces;
+    using Json;
+
+    /// <summary>
+    /// A handler class for registering your <see cref="SaveDataCache"/>.
+    /// </summary>
+    public class SaveDataHandler : ISaveDataHandler
+    {
+        /// <summary>
+        /// Main entry point for all calls to this handler.
+        /// </summary>
+        public static ISaveDataHandler Main { get; } = new SaveDataHandler();
+
+        private SaveDataHandler()
+        {
+            // Hide Constructor
+        }
+
+        T ISaveDataHandler.RegisterSaveDataCache<T>()
+        {
+            T cache = new();
+
+            IngameMenuHandler.Main.RegisterOnLoadEvent(() => cache.Load());
+            IngameMenuHandler.Main.RegisterOnSaveEvent(() => cache.Save());
+
+            return cache;
+        }
+    }
+}

--- a/SMLHelper/Interfaces/IIngameMenuHandler.cs
+++ b/SMLHelper/Interfaces/IIngameMenuHandler.cs
@@ -14,6 +14,12 @@
         void RegisterOnSaveEvent(Action onSaveAction);
 
         /// <summary>
+        /// Registers a simple <see cref="Action"/> method to invoke whenever the player loads a saved game via the in game menu.
+        /// </summary>
+        /// <param name="onLoadAction">The method to invoke.</param>
+        void RegisterOnLoadEvent(Action onLoadAction);
+
+        /// <summary>
         /// Registers a simple <see cref="Action"/> method to invoke whenever the player quits the game via the in game menu.
         /// </summary>
         /// <param name="onQuitAction">The method to invoke.</param>
@@ -27,6 +33,13 @@
         void UnregisterOnSaveEvent(Action onSaveAction);
 
         /// <summary>
+        /// Removes a method previously added through <see cref="RegisterOnLoadEvent(Action)"/> so it is no longer invoked when loading the game.<para/>
+        /// If you plan on using this, do not register an anonymous method.
+        /// </summary>
+        /// <param name="onLoadAction">The method invoked.</param>
+        void UnregisterOnLoadEvent(Action onLoadAction);
+
+        /// <summary>
         /// Removes a method previously added through <see cref="RegisterOnQuitEvent(Action)"/> so it is no longer invoked when quiting the game.<para/>
         /// If you plan on using this, do not register an anonymous method.
         /// </summary>
@@ -38,6 +51,12 @@
         /// </summary>
         /// <param name="onSaveAction">The method to invoke. This action will not be invoked a second time.</param>
         void RegisterOneTimeUseOnSaveEvent(Action onSaveAction);
+
+        /// <summary>
+        /// Registers a simple <see cref="Action"/> method to invoke the <c>first time</c> the player loads a saved game via the in game menu.
+        /// </summary>
+        /// <param name="onLoadAction">The method to invoke. This action will not be invoked a second time.</param>
+        void RegisterOneTimeUseOnLoadEvent(Action onLoadAction);
 
         /// <summary>
         /// Registers a simple <see cref="Action"/> method to invoke the <c>first time</c> the player quits the game via the in game menu.

--- a/SMLHelper/Interfaces/ISaveDataHandler.cs
+++ b/SMLHelper/Interfaces/ISaveDataHandler.cs
@@ -1,0 +1,18 @@
+﻿namespace SMLHelper.V2.Interfaces
+{
+    using Json;
+
+    /// <summary>
+    /// A handler class for registering your <see cref="SaveDataCache"/>.
+    /// </summary>
+    public interface ISaveDataHandler
+    {
+        /// <summary>
+        /// Registers your <see cref="SaveDataCache"/> to be automatically loaded and saved whenever the game is.
+        /// </summary>
+        /// <typeparam name="T">A class derived from <see cref="SaveDataCache"/> to hold your save data.</typeparam>
+        /// <returns>An instance of the <typeparamref name="T"/> : <see cref="SaveDataCache"/> with values loaded
+        /// from the json file on disk whenever a save slot is loaded.</returns>
+        T RegisterSaveDataCache<T>() where T : SaveDataCache, new();
+    }
+}

--- a/SMLHelper/Json/Attributes/FileNameAttribute.cs
+++ b/SMLHelper/Json/Attributes/FileNameAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace SMLHelper.V2.Json.Attributes
+{
+    /// <summary>
+    /// Attribute used to specify a file name for use with a <see cref="JsonFile"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class FileNameAttribute : Attribute
+    {
+        /// <summary>
+        /// The filename.
+        /// </summary>
+        public string FileName { get; }
+
+        /// <summary>
+        /// Used to specify the file name for a <see cref="JsonFile"/>.
+        /// </summary>
+        /// <param name="fileName"></param>
+        public FileNameAttribute(string fileName)
+        {
+            FileName = fileName;
+        }
+    }
+}

--- a/SMLHelper/Json/ConfigFile.cs
+++ b/SMLHelper/Json/ConfigFile.cs
@@ -36,7 +36,9 @@ namespace SMLHelper.V2.Json
             new KeyCodeConverter(),
             new FloatConverter(),
             new StringEnumConverter(),
-            new VersionConverter()
+            new VersionConverter(),
+            new Vector3Converter(),
+            new QuaternionConverter()
         };
 
         /// <summary>

--- a/SMLHelper/Json/ConfigFile.cs
+++ b/SMLHelper/Json/ConfigFile.cs
@@ -1,19 +1,20 @@
-﻿namespace SMLHelper.V2.Json
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Linq;
+#if SUBNAUTICA_STABLE
+using Oculus.Newtonsoft.Json;
+using Oculus.Newtonsoft.Json.Converters;
+#else
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+#endif
+
+namespace SMLHelper.V2.Json
 {
     using Converters;
     using ExtensionMethods;
     using Interfaces;
-    using System;
-    using System.IO;
-    using System.Reflection;
-    using System.Linq;
-#if SUBNAUTICA_STABLE
-    using Oculus.Newtonsoft.Json;
-    using Oculus.Newtonsoft.Json.Converters;
-#else
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
-#endif
 
     /// <summary>
     /// A simple implementation of <see cref="IJsonFile"/> for use with config files.
@@ -163,25 +164,5 @@
         public void SaveWithConverters(params JsonConverter[] jsonConverters)
             => this.SaveJson(JsonFilePath,
                 AlwaysIncludedJsonConverters.Concat(jsonConverters).Distinct().ToArray());
-    }
-
-    /// <summary>
-    /// Contains basic information for a <see cref="ConfigFile"/> event.
-    /// </summary>
-    public class ConfigFileEventArgs : EventArgs
-    {
-        /// <summary>
-        /// The instance of the <see cref="ConfigFile"/> this event pertains to.
-        /// </summary>
-        public ConfigFile Instance { get; }
-
-        /// <summary>
-        /// Instantiates a new <see cref="ConfigFileEventArgs"/>.
-        /// </summary>
-        /// <param name="instance">The <see cref="ConfigFile"/> instance the event pertains to.</param>
-        public ConfigFileEventArgs(ConfigFile instance)
-        {
-            Instance = instance;
-        }
     }
 }

--- a/SMLHelper/Json/ConfigFileEventArgs.cs
+++ b/SMLHelper/Json/ConfigFileEventArgs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace SMLHelper.V2.Json
+{
+    /// <summary>
+    /// Contains basic information for a <see cref="ConfigFile"/> event.
+    /// </summary>
+    public class ConfigFileEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The instance of the <see cref="ConfigFile"/> this event pertains to.
+        /// </summary>
+        public ConfigFile Instance { get; }
+
+        /// <summary>
+        /// Instantiates a new <see cref="ConfigFileEventArgs"/>.
+        /// </summary>
+        /// <param name="instance">The <see cref="ConfigFile"/> instance the event pertains to.</param>
+        public ConfigFileEventArgs(ConfigFile instance)
+        {
+            Instance = instance;
+        }
+    }
+}

--- a/SMLHelper/Json/JsonFile.cs
+++ b/SMLHelper/Json/JsonFile.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Linq;
+#if SUBNAUTICA_STABLE
+using Oculus.Newtonsoft.Json;
+using Oculus.Newtonsoft.Json.Converters;
+#else
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+#endif
+
+namespace SMLHelper.V2.Json
+{
+    using Converters;
+    using ExtensionMethods;
+    using Interfaces;
+
+    /// <summary>
+    /// A simple abstract implementation of <see cref="IJsonFile"/>.
+    /// </summary>
+    public abstract class JsonFile : IJsonFile
+    {
+        /// <summary>
+        /// The file path at which the JSON file is accessible for reading and writing.
+        /// </summary>
+        [JsonIgnore]
+        public abstract string JsonFilePath { get; }
+
+        [JsonIgnore]
+        private static readonly JsonConverter[] alwaysIncludedJsonConverters = new JsonConverter[] {
+            new FloatConverter(),
+            new KeyCodeConverter(),
+            new StringEnumConverter(),
+            new VersionConverter(),
+            new Vector3Converter(),
+            new QuaternionConverter()
+        };
+
+        /// <summary>
+        /// The <see cref="JsonConverter"/>s that should always be used when reading/writing JSON data.
+        /// </summary>
+        /// <seealso cref="alwaysIncludedJsonConverters"/>
+        public virtual JsonConverter[] AlwaysIncludedJsonConverters => alwaysIncludedJsonConverters;
+
+        /// <summary>
+        /// An event that is invoked whenever the <see cref="JsonFile"/> is about to load data from disk.
+        /// </summary>
+        [JsonIgnore]
+        public EventHandler<JsonFileEventArgs> OnStartedLoading;
+        /// <summary>
+        /// An event that is invoked whenever the <see cref="JsonFile"/> has finished loading data from disk.
+        /// </summary>
+        [JsonIgnore]
+        public EventHandler<JsonFileEventArgs> OnFinishedLoading;
+
+        /// <summary>
+        /// An event that is invoked whenever the <see cref="JsonFile"/> is about to save data to disk.
+        /// </summary>
+        [JsonIgnore]
+        public EventHandler<JsonFileEventArgs> OnStartedSaving;
+        /// <summary>
+        /// An event that is invoked whenever the <see cref="JsonFile"/> has finished saving data to disk.
+        /// </summary>
+        [JsonIgnore]
+        public EventHandler<JsonFileEventArgs> OnFinishedSaving;
+
+        /// <summary>
+        /// Loads the JSON properties from the file on disk into the <see cref="JsonFile"/>.
+        /// </summary>
+        /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
+        /// already exist.</param>
+        /// <seealso cref="Save()"/>
+        /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
+        public virtual void Load(bool createFileIfNotExist = true)
+        {
+            var e = new JsonFileEventArgs(this);
+            OnStartedLoading?.Invoke(this, e);
+            this.LoadJson(JsonFilePath, createFileIfNotExist, AlwaysIncludedJsonConverters.Distinct().ToArray());
+            OnFinishedLoading?.Invoke(this, e);
+        }
+
+        /// <summary>
+        /// Saves the current fields and properties of the <see cref="JsonFile"/> as JSON properties to the file on disk.
+        /// </summary>
+        /// <seealso cref="Load(bool)"/>
+        /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
+        public virtual void Save()
+        {
+            var e = new JsonFileEventArgs(this);
+            OnStartedSaving?.Invoke(this, e);
+            this.SaveJson(JsonFilePath, AlwaysIncludedJsonConverters.Distinct().ToArray());
+            OnFinishedSaving?.Invoke(this, e);
+        }
+
+        /// <summary>
+        /// Loads the JSON properties from the file on disk into the <see cref="JsonFile"/>.
+        /// </summary>
+        /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
+        /// already exist.</param>
+        /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for serialization.
+        /// The <see cref="AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
+        /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
+        /// <seealso cref="Load(bool)"/>
+        public virtual void LoadWithConverters(bool createFileIfNotExist = true, params JsonConverter[] jsonConverters)
+            => this.LoadJson(JsonFilePath, true,
+                AlwaysIncludedJsonConverters.Concat(jsonConverters).Distinct().ToArray());
+
+        /// <summary>
+        /// Saves the current fields and properties of the <see cref="JsonFile"/> as JSON properties to the file on disk.
+        /// </summary>
+        /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for deserialization.
+        /// The <see cref="AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
+        /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
+        /// <seealso cref="Save"/>
+        public virtual void SaveWithConverters(params JsonConverter[] jsonConverters)
+            => this.SaveJson(JsonFilePath,
+                AlwaysIncludedJsonConverters.Concat(jsonConverters).Distinct().ToArray());
+    }
+}

--- a/SMLHelper/Json/JsonFileEventArgs.cs
+++ b/SMLHelper/Json/JsonFileEventArgs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace SMLHelper.V2.Json
+{
+    /// <summary>
+    /// Contains basic information for a <see cref="JsonFile"/> event.
+    /// </summary>
+    public class JsonFileEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The instance of the <see cref="JsonFile"/> this event pertains to.
+        /// </summary>
+        public JsonFile Instance { get; }
+
+        /// <summary>
+        /// Instantiates a new <see cref="JsonFileEventArgs"/>.
+        /// </summary>
+        /// <param name="instance">The <see cref="JsonFile"/> instance the event pertains to.</param>
+        public JsonFileEventArgs(JsonFile instance)
+        {
+            Instance = instance;
+        }
+    }
+}

--- a/SMLHelper/Json/SaveDataCache.cs
+++ b/SMLHelper/Json/SaveDataCache.cs
@@ -1,0 +1,130 @@
+﻿using QModManager.API;
+using System;
+using System.IO;
+using System.Reflection;
+#if SUBNAUTICA_STABLE
+using Oculus.Newtonsoft.Json;
+#else
+using Newtonsoft.Json;
+#endif
+
+namespace SMLHelper.V2.Json
+{
+    using Attributes;
+    using Interfaces;
+
+    /// <summary>
+    /// An abstract implementation of <see cref="IJsonFile"/> intended for use with caching per-save data.
+    /// </summary>
+    public abstract class SaveDataCache : JsonFile
+    {
+        private string QModId { get; init; }
+
+        private bool InGame => string.IsNullOrWhiteSpace(SaveLoadManager.GetTemporarySavePath());
+
+        private string jsonFileName = null;
+        private string JsonFileName => jsonFileName ??= GetType().GetCustomAttribute<FileNameAttribute>() switch
+        {
+            FileNameAttribute fileNameAttribute => fileNameAttribute.FileName,
+            _ => QModId
+        };
+
+        /// <summary>
+        /// The file path at which the JSON file is accessible for reading and writing.
+        /// </summary>
+        public override string JsonFilePath => Path.Combine(SaveLoadManager.GetTemporarySavePath(), QModId, $"{JsonFileName}.json");
+
+        /// <summary>
+        /// Creates a new instance of <see cref="SaveDataCache"/>, parsing the file name from <see cref="FileNameAttribute"/>
+        /// if declared, or with default values otherwise.
+        /// </summary>
+        public SaveDataCache()
+        {
+            QModId = QModServices.Main.FindModByAssembly(GetType().Assembly).Id;
+        }
+
+        /// <summary>
+        /// Loads the JSON properties from the file on disk into the <see cref="SaveDataCache"/>.
+        /// </summary>
+        /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
+        /// already exist.</param>
+        /// <seealso cref="Save()"/>
+        /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
+        /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>
+        public override void Load(bool createFileIfNotExist = true)
+        {
+            if (InGame)
+            {
+                base.Load(createFileIfNotExist);
+                Logger.Log($"[{QModId}] Loaded save data from {JsonFileName}.json");
+            }
+            else
+            {
+                throw new InvalidOperationException($"[{QModId}] Cannot load save data when not in game!");
+            }
+        }
+
+        /// <summary>
+        /// Saves the current fields and properties of the <see cref="SaveDataCache"/> as JSON properties to the file on disk.
+        /// </summary>
+        /// <seealso cref="Load(bool)"/>
+        /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
+        /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>
+        public override void Save()
+        {
+            if (InGame)
+            {
+                base.Save();
+                Logger.Log($"[{QModId}] Saved save data to {JsonFileName}.json");
+            }
+            else
+            {
+                throw new InvalidOperationException($"[{QModId}] Cannot save save data when not in game!");
+            }
+        }
+
+        /// <summary>
+        /// Loads the JSON properties from the file on disk into the <see cref="SaveDataCache"/>.
+        /// </summary>
+        /// <param name="createFileIfNotExist">Whether a new JSON file should be created with default values if it does not
+        /// already exist.</param>
+        /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for serialization.
+        /// The <see cref="JsonFile.AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
+        /// <seealso cref="SaveWithConverters(JsonConverter[])"/>
+        /// <seealso cref="Load(bool)"/>
+        /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>
+        public override void LoadWithConverters(bool createFileIfNotExist = true, params JsonConverter[] jsonConverters)
+        {
+            if (InGame)
+            {
+                base.LoadWithConverters(createFileIfNotExist, jsonConverters);
+                Logger.Log($"[{QModId}] Loaded save data from {JsonFileName}.json");
+            }
+            else
+            {
+                throw new InvalidOperationException($"[{QModId}] Cannot load save data when not in game!");
+            }
+        }
+
+        /// <summary>
+        /// Saves the current fields and properties of the <see cref="SaveDataCache"/> as JSON properties to the file on disk.
+        /// </summary>
+        /// <param name="jsonConverters">Optional <see cref="JsonConverter"/>s to be used for deserialization.
+        /// The <see cref="JsonFile.AlwaysIncludedJsonConverters"/> will always be used, regardless of whether you pass them.</param>
+        /// <seealso cref="LoadWithConverters(bool, JsonConverter[])"/>
+        /// <seealso cref="Save"/>
+        /// <exception cref="InvalidOperationException">Thrown when the player is not in-game.</exception>
+        public override void SaveWithConverters(params JsonConverter[] jsonConverters)
+        {
+            if (InGame)
+            {
+                base.SaveWithConverters(jsonConverters);
+                Logger.Log($"[{QModId}] Saved save data to {JsonFileName}.json");
+            }
+            else
+            {
+                throw new InvalidOperationException($"[{QModId}] Cannot save save data when not in game!");
+            }
+        }
+    }
+}

--- a/SMLHelper/Json/SaveDataCache.cs
+++ b/SMLHelper/Json/SaveDataCache.cs
@@ -20,7 +20,7 @@ namespace SMLHelper.V2.Json
     {
         private string QModId { get; init; }
 
-        private bool InGame => string.IsNullOrWhiteSpace(SaveLoadManager.GetTemporarySavePath());
+        private bool InGame => !string.IsNullOrWhiteSpace(SaveLoadManager.GetTemporarySavePath());
 
         private string jsonFileName = null;
         private string JsonFileName => jsonFileName ??= GetType().GetCustomAttribute<FileNameAttribute>() switch

--- a/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
+++ b/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
@@ -124,8 +124,8 @@
             {
                 // Enum-based choice where the values are defined as custom strings
                 string[] options = choiceAttribute.Options;
-                string value = memberInfoMetadata.GetValue(ConfigFileMetadata.Config).ToString();
-                int index = Math.Max(Array.IndexOf(Enum.GetValues(memberInfoMetadata.ValueType), value), 0);
+                string name = memberInfoMetadata.GetValue(ConfigFileMetadata.Config).ToString();
+                int index = Math.Max(Array.IndexOf(Enum.GetNames(memberInfoMetadata.ValueType), name), 0);
                 AddChoiceOption(id, label, options, index);
             }
             else if (memberInfoMetadata.ValueType == typeof(string))

--- a/SMLHelper/Patchers/IngameMenuPatcher.cs
+++ b/SMLHelper/Patchers/IngameMenuPatcher.cs
@@ -7,15 +7,19 @@
     internal class IngameMenuPatcher
     {
         private static readonly List<Action> oneTimeUseOnSaveEvents = new List<Action>();
+        private static readonly List<Action> oneTimeUseOnLoadEvents = new List<Action>();
         private static readonly List<Action> oneTimeUseOnQuitEvents = new List<Action>();
 
         internal static Action OnSaveEvents;
+        internal static Action OnLoadEvents;
         internal static Action OnQuitEvents;
 
         public static void Patch(Harmony harmony)
         {
             harmony.Patch(AccessTools.Method(typeof(IngameMenu), nameof(IngameMenu.SaveGame)),
                 postfix: new HarmonyMethod(AccessTools.Method(typeof(IngameMenuPatcher), nameof(InvokeSaveEvents))));
+            harmony.Patch(AccessTools.Method(typeof(uGUI_SceneLoading), nameof(uGUI_SceneLoading.BeginAsyncSceneLoad)),
+                postfix: new HarmonyMethod(AccessTools.Method(typeof(IngameMenuPatcher), nameof(InvokeLoadEvents))));
             harmony.Patch(AccessTools.Method(typeof(IngameMenu), nameof(IngameMenu.QuitGame)),
                 postfix: new HarmonyMethod(AccessTools.Method(typeof(IngameMenuPatcher), nameof(InvokeQuitEvents))));
         }
@@ -23,6 +27,11 @@
         internal static void AddOneTimeUseSaveEvent(Action onSaveAction)
         {
             oneTimeUseOnSaveEvents.Add(onSaveAction);
+        }
+
+        internal static void AddOneTimeUseLoadEvent(Action onLoadAction)
+        {
+            oneTimeUseOnLoadEvents.Add(onLoadAction);
         }
 
         internal static void AddOneTimeUseQuitEvent(Action onQuitAction)
@@ -40,6 +49,22 @@
                     action.Invoke();
 
                 oneTimeUseOnSaveEvents.Clear();
+            }
+        }
+
+        internal static void InvokeLoadEvents(string sceneName)
+        {
+            if (sceneName == "Main")
+            {
+                OnLoadEvents?.Invoke();
+
+                if (oneTimeUseOnLoadEvents.Count > 0)
+                {
+                    foreach (Action action in oneTimeUseOnLoadEvents)
+                        action.Invoke();
+
+                    oneTimeUseOnLoadEvents.Clear();
+                }
             }
         }
 

--- a/SMLHelper/Patchers/LargeWorldStreamerPatcher.cs
+++ b/SMLHelper/Patchers/LargeWorldStreamerPatcher.cs
@@ -60,19 +60,19 @@ namespace SMLHelper.V2.Patchers
                     spawnInfos.Remove(savedSpawnInfo);
             }
 
-            IngameMenuHandler.RegisterOneTimeUseOnSaveEvent(() => SaveData(file));
+            IngameMenuHandler.RegisterOneTimeUseOnSaveEvent(() => SaveData());
 
             Initialize();
             Logger.Debug("Coordinated Spawns have been initialized in the current save.");
         }
 
-        private static void SaveData(string file)
+        private static void SaveData()
         {
+            var file = Path.Combine(SaveLoadManager.GetTemporarySavePath(), "CoordinatedSpawnsInitialized.smlhelper");
             using var writer = new StreamWriter(file);
             try
             {
                 string data = JsonConvert.SerializeObject(savedSpawnInfos, Formatting.Indented, new Vector3Converter(), new QuaternionConverter());
-                //Logger.Info(data);
                 writer.Write(data);
                 writer.Flush();
                 writer.Close();

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.1.1")]
-[assembly: AssemblyFileVersion("2.10.1.1")]
+[assembly: AssemblyVersion("2.10.1.2")]
+[assembly: AssemblyFileVersion("2.10.1.2")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.1.2")]
-[assembly: AssemblyFileVersion("2.10.1.2")]
+[assembly: AssemblyVersion("2.11.0.0")]
+[assembly: AssemblyFileVersion("2.11.0.0")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.1.0")]
-[assembly: AssemblyFileVersion("2.10.1.0")]
+[assembly: AssemblyVersion("2.10.1.1")]
+[assembly: AssemblyFileVersion("2.10.1.1")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Handlers\CoordinatedSpawnsHandler.cs" />
     <Compile Include="Handlers\CustomSoundHandler.cs" />
     <Compile Include="Handlers\PingHandler.cs" />
+    <Compile Include="Handlers\SaveDataHandler.cs" />
     <Compile Include="Handlers\SurvivalHandler.cs" />
     <Compile Include="Handlers\TechCategoryHandler.cs" />
     <Compile Include="Handlers\TechGroupHandler.cs" />
@@ -163,10 +164,13 @@
     <Compile Include="Interfaces\IModOptionEventAttribute.cs" />
     <Compile Include="Interfaces\IConsoleCommandHandler.cs" />
     <Compile Include="Interfaces\IPingHandler.cs" />
+    <Compile Include="Interfaces\ISaveDataHandler.cs" />
     <Compile Include="Interfaces\ISurvivalHandler.cs" />
     <Compile Include="Interfaces\ITechCategoryHandler.cs" />
     <Compile Include="Interfaces\ITechGroupHandler.cs" />
+    <Compile Include="Json\Attributes\FileNameAttribute.cs" />
     <Compile Include="Json\ConfigFileAttribute.cs" />
+    <Compile Include="Json\ConfigFileEventArgs.cs" />
     <Compile Include="Json\Converters\FloatConverter.cs" />
     <Compile Include="Json\Converters\QuaternionConverter.cs" />
     <Compile Include="Json\Converters\Vector3Converter.cs" />
@@ -212,6 +216,9 @@
     <Compile Include="Interfaces\ITechTypeHandler.cs" />
     <Compile Include="Interfaces\ITechTypeHandlerInternal.cs" />
     <Compile Include="Interfaces\IWorldEntityDatabaseHandler.cs" />
+    <Compile Include="Json\JsonFile.cs" />
+    <Compile Include="Json\JsonFileEventArgs.cs" />
+    <Compile Include="Json\SaveDataCache.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="MonoBehaviours\EntitySpawner.cs" />
     <Compile Include="MonoBehaviours\Fixer.cs" />

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.1.2",
+    "Version": "2.11",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.1.1",
+    "Version": "2.10.1.2",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.1",
+    "Version": "2.10.1.1",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.1",
+    "Version": "2.10.1.1",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.1.2",
+    "Version": "2.11",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.10.1.1",
+    "Version": "2.10.1.2",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll",


### PR DESCRIPTION
## Changes in this version
This is a backwards-compatible feature release.
  - #233
    - New feature: Added the public abstract class `JsonFile` to the `SMLHelper.V2.Json` namespace. This is a very basic implementation of `IJsonFile`, intended for use for saving and loading simple json files, and can be extended as needed for custom purposes.
    - New feature: Added the public abstract class `SaveDataCache` to the `SMLHelper.V2.Json` namespace, which extends from the new `JsonFile` class. This abstract class is intended to be used in a similar manner as `ConfigFile`, but for the purpose of per-mod-per-save data. See the linked PR for more details and example usages.
    - New feature: Adds a `SaveDataHandler` for registering a `SaveDataCache` with SMLHelper to be automatically saved/loaded to/from disk when appropriate.
    - New feature: Added methods to the `InGameMenuHandler` that provide the ability to register callbacks with SMLHelper to be invoked whenever a game is loaded, similar to the methods it already provides that invoke a callback when the user saves or quits the game.
    - Maintenance: Example Mod project updated to include examples of how to use the `SaveDataCache` and `SaveDataHandler` features.
  - #236
    - Enhancement: Adds `Vector3Converter` and `QuaternionConverter` to the `AlwaysIncludedConverters` of `ConfigFile` implementations.
  - #231 
    - Bugfix: Resolved an issue where passing custom `string` names for enum-based `Choice` was incorrectly displaying the choice as if the first option was selected when the menu is first built, regardless of what option is actually selected. 
  - #234 
    - Bugfix: Resolved an issue where backing out to the main menu and loading into the game again would result in `CoordinatedSpawnsInitialized.smlhelper` not being correctly saved when the player saves the game.
  - #232
    - Maintenance: Invocation of `ConfigFile` attribute-based events are now deferred until the `OptionsPanelHandler` has finished registering the `ConfigFile` to the options menu to ensure consistency across all `ConfigFile` events.

## Builds v2.10.1.2 00a9fe3
### Subnautica
#### Stable
[SMLHelper](https://github.com/SubnauticaModding/SMLHelper/files/6803013/SMLHelper_SN.STABLE.zip)
[Example Mod](https://github.com/SubnauticaModding/SMLHelper/files/6803025/SN.STABLE.zip)

#### Experimental
[SMLHelper](https://github.com/SubnauticaModding/SMLHelper/files/6803015/SMLHelper_SN.EXP.zip)
[Example Mod](https://github.com/SubnauticaModding/SMLHelper/files/6803029/SN.EXP.zip)

### Below Zero
#### Stable
[SMLHelper Zero](https://github.com/SubnauticaModding/SMLHelper/files/6803017/SMLHelper_BZ.STABLE.zip)
[Example Mod](https://github.com/SubnauticaModding/SMLHelper/files/6803031/BZ.STABLE.zip)

#### Experimental
[SMLHelper Zero](https://github.com/SubnauticaModding/SMLHelper/files/6803018/SMLHelper_BZ.EXP.zip)
[Example Mod](https://github.com/SubnauticaModding/SMLHelper/files/6803032/BZ.EXP.zip)
