### PR TITLE
Add `Vector3Converter` and `QuaternionConverter` to `ConfigFile`

### DIFF
--- a/SMLHelper/Json/ConfigFile.cs
+++ b/SMLHelper/Json/ConfigFile.cs
@@ -36,7 +36,9 @@ namespace SMLHelper.V2.Json
             new KeyCodeConverter(),
             new FloatConverter(),
             new StringEnumConverter(),
-            new VersionConverter()
+            new VersionConverter(),
+            new Vector3Converter(),
+            new QuaternionConverter()
         };
 
         /// <summary>


### PR DESCRIPTION
## Changes made in this pull request
  - Adds the `Vector3Converter` and `QuaternionConverter` to the `AlwaysIncludedConverters` of `ConfigFile` implementations. This should resolve any issues that API consumers may have had with attempting to include `Vector3` or `Quaternion` members in `ConfigFile` implementations.