### PR TITLE
More JsonConverters

### DIFF
--- a/SMLHelper/Json/ConfigFile.cs
+++ b/SMLHelper/Json/ConfigFile.cs
@@ -40,6 +40,7 @@ namespace SMLHelper.V2.Json
             new Vector2Converter(),
             new Vector3Converter(),
             new Vector4Converter(),
+            new Vector2IntConverter(),
             new QuaternionConverter()
         };
 

--- a/SMLHelper/Json/ConfigFile.cs
+++ b/SMLHelper/Json/ConfigFile.cs
@@ -37,7 +37,9 @@ namespace SMLHelper.V2.Json
             new FloatConverter(),
             new StringEnumConverter(),
             new VersionConverter(),
+            new Vector2Converter(),
             new Vector3Converter(),
+            new Vector4Converter(),
             new QuaternionConverter()
         };
 

--- a/SMLHelper/Json/ConfigFile.cs
+++ b/SMLHelper/Json/ConfigFile.cs
@@ -41,6 +41,7 @@ namespace SMLHelper.V2.Json
             new Vector3Converter(),
             new Vector4Converter(),
             new Vector2IntConverter(),
+            new Vector3IntConverter(),
             new QuaternionConverter()
         };
 

--- a/SMLHelper/Json/Converters/Vector2Converter.cs
+++ b/SMLHelper/Json/Converters/Vector2Converter.cs
@@ -1,0 +1,56 @@
+using System;
+using UnityEngine;
+#if SUBNAUTICA_STABLE
+using Oculus.Newtonsoft.Json;
+#else
+using Newtonsoft.Json;
+#endif
+namespace SMLHelper.V2.Json.Converters
+{
+    /// <summary>
+    /// A Vector2 json converter that simplifies the Vector3 to only x,y,z serialization.
+    /// </summary>
+    public class Vector2Converter : JsonConverter
+    {
+        /// <summary>
+        /// A method that determines when this converter should process.
+        /// </summary>
+        /// <param name="objectType">the current object type</param>
+        /// <returns></returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Vector2);
+        }
+
+        /// <summary>
+        /// A method that tells Newtonsoft how to Serialize the current object.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
+        /// <param name="serializer"></param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var vector2 = (Vector2)value;
+            serializer.Serialize(writer, (Vector2Json)vector2);
+        }
+
+        /// <summary>
+        /// A method that tells Newtonsoft how to Deserialize and read the current object.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="objectType"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="serializer"></param>
+        /// <returns></returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return (Vector2)serializer.Deserialize<Vector2Json>(reader);
+        }
+    }
+
+    internal record Vector2Json(float X, float Y)
+    {
+        public static explicit operator Vector2(Vector2Json v) => new(v.X, v.Y);
+        public static explicit operator Vector2Json(Vector2 v) => new(v.x, v.y);
+    }
+}

--- a/SMLHelper/Json/Converters/Vector2Converter.cs
+++ b/SMLHelper/Json/Converters/Vector2Converter.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 namespace SMLHelper.V2.Json.Converters
 {
     /// <summary>
-    /// A Vector2 json converter that simplifies the Vector3 to only x,y,z serialization.
+    /// A Vector2 json converter that simplifies the Vector2 to only x,y serialization.
     /// </summary>
     public class Vector2Converter : JsonConverter
     {

--- a/SMLHelper/Json/Converters/Vector2IntConverter.cs
+++ b/SMLHelper/Json/Converters/Vector2IntConverter.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 namespace SMLHelper.V2.Json.Converters
 {
     /// <summary>
-    /// A Vector2 json converter that simplifies the Vector2 to only x,y serialization.
+    /// A Vector2Int json converter that simplifies the Vector2Int to only x,y serialization.
     /// </summary>
     public class Vector2IntConverter : JsonConverter
     {
@@ -19,7 +19,7 @@ namespace SMLHelper.V2.Json.Converters
         /// <returns></returns>
         public override bool CanConvert(Type objectType)
         {
-            return objectType == typeof(Vector3);
+            return objectType == typeof(Vector2Int);
         }
 
         /// <summary>

--- a/SMLHelper/Json/Converters/Vector2IntConverter.cs
+++ b/SMLHelper/Json/Converters/Vector2IntConverter.cs
@@ -1,0 +1,56 @@
+using System;
+using UnityEngine;
+#if SUBNAUTICA_STABLE
+using Oculus.Newtonsoft.Json;
+#else
+using Newtonsoft.Json;
+#endif
+namespace SMLHelper.V2.Json.Converters
+{
+    /// <summary>
+    /// A Vector2 json converter that simplifies the Vector2 to only x,y serialization.
+    /// </summary>
+    public class Vector2IntConverter : JsonConverter
+    {
+        /// <summary>
+        /// A method that determines when this converter should process.
+        /// </summary>
+        /// <param name="objectType">the current object type</param>
+        /// <returns></returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Vector3);
+        }
+
+        /// <summary>
+        /// A method that tells Newtonsoft how to Serialize the current object.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
+        /// <param name="serializer"></param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var vector2Int = (Vector2Int)value;
+            serializer.Serialize(writer, (Vector2IntJson)vector2Int);
+        }
+
+        /// <summary>
+        /// A method that tells Newtonsoft how to Deserialize and read the current object.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="objectType"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="serializer"></param>
+        /// <returns></returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return (Vector2Int)serializer.Deserialize<Vector2IntJson>(reader);
+        }
+    }
+
+    internal record Vector2IntJson(int X, int Y)
+    {
+        public static explicit operator Vector2Int(Vector2IntJson v) => new(v.X, v.Y);
+        public static explicit operator Vector2IntJson(Vector2Int v) => new(v.x, v.y);
+    }
+}

--- a/SMLHelper/Json/Converters/Vector3IntConverter.cs
+++ b/SMLHelper/Json/Converters/Vector3IntConverter.cs
@@ -1,0 +1,56 @@
+using System;
+using UnityEngine;
+#if SUBNAUTICA_STABLE
+using Oculus.Newtonsoft.Json;
+#else
+using Newtonsoft.Json;
+#endif
+namespace SMLHelper.V2.Json.Converters
+{
+    /// <summary>
+    /// A Vector3Int json converter that simplifies the Vector3Int to only x,y,z serialization.
+    /// </summary>
+    public class Vector3IntConverter : JsonConverter
+    {
+        /// <summary>
+        /// A method that determines when this converter should process.
+        /// </summary>
+        /// <param name="objectType">the current object type</param>
+        /// <returns></returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Vector3Int);
+        }
+
+        /// <summary>
+        /// A method that tells Newtonsoft how to Serialize the current object.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
+        /// <param name="serializer"></param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var vector3Int = (Vector3Int)value;
+            serializer.Serialize(writer, (Vector3IntJson)vector3Int);
+        }
+
+        /// <summary>
+        /// A method that tells Newtonsoft how to Deserialize and read the current object.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="objectType"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="serializer"></param>
+        /// <returns></returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return (Vector3Int)serializer.Deserialize<Vector3IntJson>(reader);
+        }
+    }
+
+    internal record Vector3IntJson(int X, int Y, int Z)
+    {
+        public static explicit operator Vector3Int(Vector3IntJson v) => new(v.X, v.Y, v.Z);
+        public static explicit operator Vector3IntJson(Vector3Int v) => new(v.x, v.y, v.z);
+    }
+}

--- a/SMLHelper/Json/Converters/Vector4Converter.cs
+++ b/SMLHelper/Json/Converters/Vector4Converter.cs
@@ -1,0 +1,56 @@
+using System;
+using UnityEngine;
+#if SUBNAUTICA_STABLE
+using Oculus.Newtonsoft.Json;
+#else
+using Newtonsoft.Json;
+#endif
+namespace SMLHelper.V2.Json.Converters
+{
+    /// <summary>
+    /// A Vector4 json converter that simplifies the Vector4 to only x,y,z,w serialization.
+    /// </summary>
+    public class Vector4Converter : JsonConverter
+    {
+        /// <summary>
+        /// A method that determines when this converter should process.
+        /// </summary>
+        /// <param name="objectType">the current object type</param>
+        /// <returns></returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Vector4);
+        }
+
+        /// <summary>
+        /// A method that tells Newtonsoft how to Serialize the current object.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
+        /// <param name="serializer"></param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var vector4 = (Vector4)value;
+            serializer.Serialize(writer, (Vector4Json)vector4);
+        }
+
+        /// <summary>
+        /// A method that tells Newtonsoft how to Deserialize and read the current object.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="objectType"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="serializer"></param>
+        /// <returns></returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return (Vector4)serializer.Deserialize<Vector4Json>(reader);
+        }
+    }
+
+    internal record Vector4Json(float X, float Y, float Z, float W)
+    {
+        public static explicit operator Vector4(Vector4Json v) => new(v.X, v.Y, v.Z, v.W);
+        public static explicit operator Vector4Json(Vector4 v) => new(v.x, v.y, v.z, v.w);
+    }
+}

--- a/SMLHelper/Json/JsonFile.cs
+++ b/SMLHelper/Json/JsonFile.cs
@@ -35,6 +35,7 @@ namespace SMLHelper.V2.Json
             new Vector3Converter(),
             new Vector4Converter(),
             new Vector2IntConverter(),
+            new Vector3IntConverter(),
             new QuaternionConverter()
         };
 

--- a/SMLHelper/Json/JsonFile.cs
+++ b/SMLHelper/Json/JsonFile.cs
@@ -34,6 +34,7 @@ namespace SMLHelper.V2.Json
             new Vector2Converter(),
             new Vector3Converter(),
             new Vector4Converter(),
+            new Vector2IntConverter(),
             new QuaternionConverter()
         };
 

--- a/SMLHelper/Json/JsonFile.cs
+++ b/SMLHelper/Json/JsonFile.cs
@@ -33,6 +33,7 @@ namespace SMLHelper.V2.Json
             new VersionConverter(),
             new Vector2Converter(),
             new Vector3Converter(),
+            new Vector4Converter(),
             new QuaternionConverter()
         };
 

--- a/SMLHelper/Json/JsonFile.cs
+++ b/SMLHelper/Json/JsonFile.cs
@@ -31,6 +31,7 @@ namespace SMLHelper.V2.Json
             new KeyCodeConverter(),
             new StringEnumConverter(),
             new VersionConverter(),
+            new Vector2Converter(),
             new Vector3Converter(),
             new QuaternionConverter()
         };

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -175,6 +175,7 @@
     <Compile Include="Json\Converters\QuaternionConverter.cs" />
     <Compile Include="Json\Converters\Vector2Converter.cs" />
     <Compile Include="Json\Converters\Vector3Converter.cs" />
+    <Compile Include="Json\Converters\Vector4Converter.cs" />
     <Compile Include="Json\ExtensionMethods\JsonExtensions.cs" />
     <Compile Include="Handler.cs" />
     <Compile Include="Handlers\BioReactorHandler.cs" />

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Json\ConfigFileEventArgs.cs" />
     <Compile Include="Json\Converters\FloatConverter.cs" />
     <Compile Include="Json\Converters\QuaternionConverter.cs" />
+    <Compile Include="Json\Converters\Vector2Converter.cs" />
     <Compile Include="Json\Converters\Vector3Converter.cs" />
     <Compile Include="Json\ExtensionMethods\JsonExtensions.cs" />
     <Compile Include="Handler.cs" />

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Json\Converters\FloatConverter.cs" />
     <Compile Include="Json\Converters\QuaternionConverter.cs" />
     <Compile Include="Json\Converters\Vector2Converter.cs" />
+    <Compile Include="Json\Converters\Vector2IntConverter.cs" />
     <Compile Include="Json\Converters\Vector3Converter.cs" />
     <Compile Include="Json\Converters\Vector4Converter.cs" />
     <Compile Include="Json\ExtensionMethods\JsonExtensions.cs" />

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Json\Converters\Vector2Converter.cs" />
     <Compile Include="Json\Converters\Vector2IntConverter.cs" />
     <Compile Include="Json\Converters\Vector3Converter.cs" />
+    <Compile Include="Json\Converters\Vector3IntConverter.cs" />
     <Compile Include="Json\Converters\Vector4Converter.cs" />
     <Compile Include="Json\ExtensionMethods\JsonExtensions.cs" />
     <Compile Include="Handler.cs" />


### PR DESCRIPTION
### Changes made in this pull request

  - Added many more JsonConverters for Unity data types that are likely to break Newtonsoft's (de)serialization.
  
  - Added JsonConverters in this PR are for:
    - Vector2
    - Vector4
    - Vector2Int
    - Vector3Int
  
  
[SMLHelper_SN.STABLE.zip](https://github.com/SubnauticaModding/SMLHelper/files/6830136/SMLHelper_SN.STABLE.zip)
[SMLHelper_BZ.STABLE.zip](https://github.com/SubnauticaModding/SMLHelper/files/6830137/SMLHelper_BZ.STABLE.zip)
