### PR TITLE
SMLHelper 2.11.1: ConfigFile options menu hotfix

### DIFF
--- a/Example mod/Properties/AssemblyInfo.cs
+++ b/Example mod/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.11.0.0")]
-[assembly: AssemblyFileVersion("2.11.0.0")]
+[assembly: AssemblyVersion("2.11.1.0")]
+[assembly: AssemblyFileVersion("2.11.1.0")]

--- a/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
+++ b/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
@@ -86,6 +86,9 @@
                 case SliderChangedEventArgs sliderChangedEventArgs:
                     ConfigFileMetadata.HandleSliderChanged(sender, sliderChangedEventArgs);
                     break;
+                case ToggleChangedEventArgs toggleChangedEventArgs:
+                    ConfigFileMetadata.HandleToggleChanged(sender, toggleChangedEventArgs);
+                    break;
                 case GameObjectCreatedEventArgs gameObjectCreatedEventArgs:
                     ConfigFileMetadata.HandleGameObjectCreated(sender, gameObjectCreatedEventArgs);
                     break;

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.11.0.0")]
-[assembly: AssemblyFileVersion("2.11.0.0")]
+[assembly: AssemblyVersion("2.11.1.0")]
+[assembly: AssemblyFileVersion("2.11.1.0")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.11",
+    "Version": "2.11.1",
     "Enable": true,
     "Game": "BelowZero",
     "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
     "Id": "SMLHelper",
     "DisplayName": "SMLHelper",
     "Author": "The SMLHelper Dev Team",
-    "Version": "2.11",
+    "Version": "2.11.1",
     "Enable": true,
     "Game": "Subnautica",
     "AssemblyName": "SMLHelper.dll",


### PR DESCRIPTION
## Changes made in this version
This is a hotfix release.
- 5c84fef
  - Hotfix: Resolved an issue introduced in #232, which caused toggle events to no longer be invoked appropriately due to a missing `case` in the event router.