### PR TITLE
Add initial EquipmentType Enum Patcher

### DIFF
--- a/SMLHelper/Handlers/EquipmentHandler.cs
+++ b/SMLHelper/Handlers/EquipmentHandler.cs
@@ -24,14 +24,12 @@
         /// Adds a new <see cref="Equipment" /> into the game.
         /// </summary>
         /// <param name="equipmentName">The name of the Equipment. Should not contain special characters.</param>
-        /// <param name="displayName">The display name of the Equipment. Can be anything.</param>
         /// <returns>
         /// The new <see cref="Equipment" /> that is created.
         /// </returns>
-        public EquipmentType RegisterNewEquipmentType(string equipmentName, string displayName)
+        public EquipmentType AddEquipmentType(string equipmentName)
         {
             EquipmentType equipment = EquipmentTypePatcher.AddEquipmentType(equipmentName);
-            LanguageHandler.SetLanguageLine(equipmentName, displayName);
             return equipment;
         }
 
@@ -45,14 +43,8 @@
         public bool ModdedEquipmentExists(string equipmentString)
         {
             EnumTypeCache cache = EquipmentTypePatcher.cacheManager.RequestCacheForTypeName(equipmentString, false);
-            if (cache != null) // Item Found
-            {
-                return true;
-            }
-            else // Mod not present or not yet loaded
-            {
-                return false;
-            }
+            // if we don't have it cached, the mod is not present or not yet loaded
+            return cache != null;
         }
 
         /// <summary>

--- a/SMLHelper/Handlers/EquipmentHandler.cs
+++ b/SMLHelper/Handlers/EquipmentHandler.cs
@@ -1,0 +1,82 @@
+﻿namespace SMLHelper.V2.Handlers
+{
+    using SMLHelper.V2.Handlers;
+    using SMLHelper.V2.Interfaces;
+    using SMLHelper.V2.Patchers.EnumPatching;
+    using SMLHelper.V2.Utility;
+
+    /// <summary>
+    /// A handler class for everything related to creating new Equipments.
+    /// </summary>
+    public class EquipmentHandler : IEquipmentHandler
+    {
+        /// <summary>
+        /// Main entry point for all calls to this handler.
+        /// </summary>
+        public static IEquipmentHandler Main { get; } = new EquipmentHandler();
+
+        private EquipmentHandler()
+        {
+            // Hide constructor
+        }
+
+        /// <summary>
+        /// Adds a new <see cref="Equipment" /> into the game.
+        /// </summary>
+        /// <param name="equipmentName">The name of the Equipment. Should not contain special characters.</param>
+        /// <param name="displayName">The display name of the Equipment. Can be anything.</param>
+        /// <returns>
+        /// The new <see cref="Equipment" /> that is created.
+        /// </returns>
+        public EquipmentType RegisterNewEquipmentType(string equipmentName, string displayName)
+        {
+            EquipmentType equipment = EquipmentTypePatcher.AddEquipmentType(equipmentName);
+            LanguageHandler.SetLanguageLine(equipmentName, displayName);
+            return equipment;
+        }
+
+        /// <summary>
+        /// Safely looks for a modded group from another mod in the SMLHelper EquipmentCache.
+        /// </summary>
+        /// <param name="equipmentString">The string used to define the techgroup.</param>
+        /// <returns>
+        ///   <c>True</c> if the item was found; Otherwise <c>false</c>.
+        /// </returns>
+        public bool ModdedEquipmentExists(string equipmentString)
+        {
+            EnumTypeCache cache = EquipmentTypePatcher.cacheManager.RequestCacheForTypeName(equipmentString, false);
+            if (cache != null) // Item Found
+            {
+                return true;
+            }
+            else // Mod not present or not yet loaded
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Safely looks for a modded item from another mod in the SMLHelper EquipmentCache and outputs its <see cref="Equipment" /> value when found.
+        /// </summary>
+        /// <param name="equipmentString">The string used to define the techgroup.</param>
+        /// <param name="modEquipment">The Equipment enum value of the modded. Defaults to <see cref="EquipmentType.None" /> when the item was not found.</param>
+        /// <returns>
+        ///   <c>True</c> if the item was found; Otherwise <c>false</c>.
+        /// </returns>
+        public bool TryGetModdedEquipmentType(string equipmentString, out EquipmentType modEquipment)
+        {
+            EnumTypeCache cache = EquipmentTypePatcher.cacheManager.RequestCacheForTypeName(equipmentString, false);
+            if (cache != null) // Item Found
+            {
+                modEquipment = (EquipmentType)cache.Index;
+                return true;
+            }
+            else // Mod not present or not yet loaded
+            {
+                modEquipment = EquipmentType.None;
+                return false;
+            }
+        }
+
+    }
+}

--- a/SMLHelper/Handlers/EquipmentHandler.cs
+++ b/SMLHelper/Handlers/EquipmentHandler.cs
@@ -40,7 +40,7 @@
         /// <returns>
         ///   <c>True</c> if the item was found; Otherwise <c>false</c>.
         /// </returns>
-        public bool ModdedEquipmentExists(string equipmentString)
+        public bool ModdedEquipmentTypeExists(string equipmentString)
         {
             EnumTypeCache cache = EquipmentTypePatcher.cacheManager.RequestCacheForTypeName(equipmentString, false);
             // if we don't have it cached, the mod is not present or not yet loaded

--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -55,6 +55,7 @@
             TechCategoryPatcher.Patch();
             TechGroupPatcher.Patch();
             BackgroundTypePatcher.Patch();
+            EquipmentTypePatcher.Patch();
             EnumPatcher.Patch(harmony);
 
             CraftDataPatcher.Patch(harmony);

--- a/SMLHelper/Interfaces/IEquipmentHandler.cs
+++ b/SMLHelper/Interfaces/IEquipmentHandler.cs
@@ -9,7 +9,6 @@
         /// Registers an equipment type for use when creating a equipment
         /// </summary>
         /// <param name="equipmentName">The name of the new equipment type</param>
-        /// <param name="displayName">The display name of the new equipment type</param>
         /// <returns>The newly registered EquipmentType</returns>
         EquipmentType AddEquipmentType(string equipmentName);
 
@@ -20,5 +19,12 @@
         /// <param name="moddedEquipmentType">The EquipmentType enum value. Defaults to <see cref="EquipmentType.None"/> when the EquipmentType was not found.</param>
         /// <returns><c>True</c> if the EquipmentType was found; Otherwise <c>false</c></returns>
         bool TryGetModdedEquipmentType(string equipmentTypeString, out EquipmentType moddedEquipmentType);
+
+        /// <summary>
+        ///  Checks for the existence of an added EquipmentType in the SMLHelper EquipmentTypeCache and outputs the result of the check
+        /// </summary>
+        /// <param name="equipmentString">The string used to define the modded EquipmentType</param>
+        /// <returns><c>True</c> if the EquipmentType was found; Otherwise <c>false</c></returns>
+        public bool ModdedEquipmentTypeExists(string equipmentString);
     }
 }

--- a/SMLHelper/Interfaces/IEquipmentHandler.cs
+++ b/SMLHelper/Interfaces/IEquipmentHandler.cs
@@ -11,7 +11,7 @@
         /// <param name="equipmentName">The name of the new equipment type</param>
         /// <param name="displayName">The display name of the new equipment type</param>
         /// <returns>The newly registered EquipmentType</returns>
-        EquipmentType RegisterNewEquipmentType(string equipmentName, string displayName);
+        EquipmentType AddEquipmentType(string equipmentName);
 
         /// <summary>
         /// Safely looks for a modded equipment type in the SMLHelper EquipmentTypeCache and outputs its <see cref="EquipmentType"/> value when found.

--- a/SMLHelper/Interfaces/IEquipmentHandler.cs
+++ b/SMLHelper/Interfaces/IEquipmentHandler.cs
@@ -1,0 +1,24 @@
+﻿namespace SMLHelper.V2.Interfaces
+{
+    /// <summary>
+    /// A handler related to EquipmentTypes
+    /// </summary>
+    public interface IEquipmentHandler
+    {
+        /// <summary>
+        /// Registers an equipment type for use when creating a equipment
+        /// </summary>
+        /// <param name="equipmentName">The name of the new equipment type</param>
+        /// <param name="displayName">The display name of the new equipment type</param>
+        /// <returns>The newly registered EquipmentType</returns>
+        EquipmentType RegisterNewEquipmentType(string equipmentName, string displayName);
+
+        /// <summary>
+        /// Safely looks for a modded equipment type in the SMLHelper EquipmentTypeCache and outputs its <see cref="EquipmentType"/> value when found.
+        /// </summary>
+        /// <param name="equipmentTypeString">The string used to define the modded EquipmentType</param>
+        /// <param name="moddedEquipmentType">The EquipmentType enum value. Defaults to <see cref="EquipmentType.None"/> when the EquipmentType was not found.</param>
+        /// <returns><c>True</c> if the EquipmentType was found; Otherwise <c>false</c></returns>
+        bool TryGetModdedEquipmentType(string equipmentTypeString, out EquipmentType moddedEquipmentType);
+    }
+}

--- a/SMLHelper/Patchers/EnumPatching/EnumPatcher.cs
+++ b/SMLHelper/Patchers/EnumPatching/EnumPatcher.cs
@@ -42,6 +42,10 @@
             {
                 __result = GetValues(BackgroundTypePatcher.cacheManager, __result);
             }
+            else if (enumType == typeof(EquipmentType))
+            {
+                __result = GetValues(EquipmentTypePatcher.cacheManager, __result);
+            }
         }
 
         private static T[] GetValues<T>(EnumCacheManager<T> cacheManager, Array __result) where T : Enum
@@ -65,7 +69,8 @@
                 IsDefined(PingTypePatcher.cacheManager, enumType, value) ||
                 IsDefined(TechGroupPatcher.cacheManager, enumType, value) ||
                 IsDefined(TechCategoryPatcher.cacheManager, enumType, value) ||
-                IsDefined(BackgroundTypePatcher.cacheManager, enumType, value))
+                IsDefined(BackgroundTypePatcher.cacheManager, enumType, value) ||
+                IsDefined(EquipmentTypePatcher.cacheManager, enumType, value))
             {
                 __result = true;
                 return false;
@@ -113,6 +118,11 @@
                 __result = backgroundType;
                 return false;
             }
+            else if (enumType == typeof(EquipmentType) && EquipmentTypePatcher.cacheManager.TryParse(value, out EquipmentType equipmentType))
+            {
+                __result = equipmentType;
+                return false;
+            }
             return true;
         }
 
@@ -144,6 +154,10 @@
 
                 case CraftData.BackgroundType backgroundType when BackgroundTypePatcher.cacheManager.TryGetValue(backgroundType, out var backgroundTypeName):
                     __result = backgroundTypeName;
+                    return false;
+
+                case EquipmentType equipmentType when EquipmentTypePatcher.cacheManager.TryGetValue(equipmentType, out var equipmentTypeName):
+                    __result = equipmentTypeName;
                     return false;
 
                 default:

--- a/SMLHelper/Patchers/EnumPatching/EquipmentTypePatcher.cs
+++ b/SMLHelper/Patchers/EnumPatching/EquipmentTypePatcher.cs
@@ -1,0 +1,55 @@
+﻿namespace SMLHelper.V2.Patchers.EnumPatching
+{
+    using System;
+    using System.Collections.Generic;
+    using SMLHelper.V2.Assets;
+    using Handlers;
+    using Utility;
+
+    internal class EquipmentTypePatcher
+    {
+        private const string EnumName = "EquipmentType";
+        internal static readonly int startingIndex = 1000;
+
+        internal static readonly EnumCacheManager<EquipmentType> cacheManager =
+            new EnumCacheManager<EquipmentType>(
+                enumTypeName: EnumName,
+                startingIndex: startingIndex,
+                bannedIDs: ExtBannedIdManager.GetBannedIdsFor(EnumName, PreRegisteredEquipmentTypes()));
+
+        private static List<int> PreRegisteredEquipmentTypes()
+        {
+            var preRegistered = new List<int>();
+            foreach (EquipmentType type in Enum.GetValues(typeof(EquipmentType)))
+            {
+                var typeCode = (int) type;
+                if (typeCode >= startingIndex && !preRegistered.Contains(typeCode))
+                {
+                    preRegistered.Add(typeCode);
+                }
+            }
+            Logger.Log($"Finished known EquipmentType exclusion. {preRegistered.Count} IDs were added in ban list.");
+            return preRegistered;
+        }
+
+        internal static EquipmentType AddEquipmentType(string name)
+        {
+            var cache = cacheManager.RequestCacheForTypeName(name) ?? new EnumTypeCache()
+            {
+                Name = name,
+                Index = cacheManager.GetNextAvailableIndex()
+            };
+            var equipmentType = (EquipmentType) cache.Index;
+            cacheManager.Add(equipmentType, cache.Index, cache.Name);
+            Logger.Log($"Successfully added EquipmentType: '{name}' to Index: '{cache.Index}'", LogLevel.Debug);
+            return equipmentType;
+        }
+
+        internal static void Patch()
+        {
+            IngameMenuHandler.Main.RegisterOneTimeUseOnSaveEvent(() => cacheManager.SaveCache());
+            Logger.Log($"Added {cacheManager.ModdedKeysCount} EquipmentTypes succesfully into the game.");
+            Logger.Log("EquipmentTypePatcher is done.", LogLevel.Debug);
+        }
+    }
+}

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Handlers\BackgroundTypeHandler.cs" />
     <Compile Include="Handlers\CoordinatedSpawnsHandler.cs" />
     <Compile Include="Handlers\CustomSoundHandler.cs" />
+    <Compile Include="Handlers\EquipmentHandler.cs" />
     <Compile Include="Handlers\PingHandler.cs" />
     <Compile Include="Handlers\SaveDataHandler.cs" />
     <Compile Include="Handlers\SurvivalHandler.cs" />
@@ -171,6 +172,7 @@
     <Compile Include="Interfaces\IModOptionAttribute.cs" />
     <Compile Include="Interfaces\IModOptionEventAttribute.cs" />
     <Compile Include="Interfaces\IConsoleCommandHandler.cs" />
+    <Compile Include="Interfaces\IEquipmentHandler.cs" />
     <Compile Include="Interfaces\IPingHandler.cs" />
     <Compile Include="Interfaces\ISaveDataHandler.cs" />
     <Compile Include="Interfaces\ISurvivalHandler.cs" />
@@ -270,6 +272,7 @@
     <Compile Include="Patchers\CraftTreePatcher.cs" />
     <Compile Include="Patchers\EnumPatching\CraftTreeTypePatcher.cs" />
     <Compile Include="Patchers\EnumPatching\EnumPatcher.cs" />
+    <Compile Include="Patchers\EnumPatching\EquipmentTypePatcher.cs" />
     <Compile Include="Patchers\EnumPatching\TechCategoryPatcher.cs" />
     <Compile Include="Patchers\EnumPatching\TechGroupPatcher.cs" />
     <Compile Include="Patchers\FishPatcher.cs" />


### PR DESCRIPTION
### Changes made in this pull request

  - Adds functionality for registering and retrieving novel "EquipmentType" enumeration values
  - Follows the example of similar enumeration patchers
  - Works well when tested with VehicleFramework
