### PR TITLE
Fix Double Register when using loot distribution data

### DIFF
--- a/SMLHelper/Assets/Spawnable.cs
+++ b/SMLHelper/Assets/Spawnable.cs
@@ -136,9 +136,10 @@
 
                 if(EntityInfo != null)
                 {
-                    WorldEntityDatabaseHandler.AddCustomInfo(ClassID, EntityInfo);
                     if(BiomesToSpawnIn != null)
                         LootDistributionHandler.AddLootDistributionData(this, BiomesToSpawnIn, EntityInfo);
+                    else
+                        WorldEntityDatabaseHandler.AddCustomInfo(ClassID, EntityInfo);
                 }
 
                 if (CoordinatedSpawns != null)


### PR DESCRIPTION
### Changes made in this pull request

  - If else for WEI register instead of both.
