### PR TITLE
Add 7Zip Command Line NuGet package back

### DIFF
--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -329,6 +329,7 @@
     <None Include="mod_BelowZero.json" Condition="$(Configuration.Contains('BZ.'))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/SMLHelper/packages.config
+++ b/SMLHelper/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="7-Zip.CommandLine" version="18.1.0" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
### Changes made in this pull request
  - Noticed that the 7Zip Command Line NuGet package had been removed from the project for some reason, even though it was still being used in the build scripts. Added it back.