### PR TITLE
Performance Improvement for CustomSoundPatcher

### DIFF
--- a/SMLHelper/Patchers/CustomSoundPatcher.cs
+++ b/SMLHelper/Patchers/CustomSoundPatcher.cs
@@ -26,6 +26,14 @@ namespace SMLHelper.V2.Patchers
             harmony.PatchAll(typeof(CustomSoundPatcher));
             Logger.Debug("CustomSoundPatcher is done.");
         }
+        
+        [HarmonyPatch(typeof(PDASounds), nameof(PDASounds.Deinitialize))]
+        [HarmonyPrefix]
+        public static void PDASounds_Deinitialize_Postfix()
+        {
+            EmitterPlayedChannels.Clear();
+            PlayedChannels.Clear();
+        }
 
 #if  SUBNAUTICA
         


### PR DESCRIPTION
### Changes made in this pull request

  - Added a `DeInitialize` method for the `CustomSoundPatcher` class.
  
This could cause a noticeable hit in performance at best, and a memory leak at worse. I thought I already had this pushed but apparently it didn't make it to SMLHelper 2.13.4.