### PR TITLE
Coordinated Spawns Enhancements - Callbacks

### DIFF
--- a/Example mod/Mod.cs
+++ b/Example mod/Mod.cs
@@ -89,6 +89,13 @@ namespace SMLHelper.V2.Examples
             /// with the <see cref="ConsoleCommandAttribute"/>. See <see cref="MyAttributedCommand(string, int, bool)"/> below
             /// for an example.
             ConsoleCommandsHandler.Main.RegisterConsoleCommands(typeof(ExampleMod));
+            
+            // Here we spawn a Titanium at 0,0,0 coordinates. when the object is successfully spawned, the game will popup the desired message
+            // which is defined in our delegate.
+            CoordinatedSpawnsHandler.Main.RegisterCoordinatedSpawn(new SpawnInfo(TechType.Titanium, Vector3.zero, obj =>
+            {
+                ErrorMessage.AddMessage($"{obj} spawned via CoordinatedSpawns system at {obj.transform.position} position.");
+            }));
 
             Logger.Log(Logger.Level.Info, "Patched successfully!");
         }

--- a/Example mod/Properties/AssemblyInfo.cs
+++ b/Example mod/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.13.5")]
-[assembly: AssemblyFileVersion("2.13.5")]
+[assembly: AssemblyVersion("2.14.0.1")]
+[assembly: AssemblyFileVersion("2.14.0.1")]

--- a/Example mod/mod.json
+++ b/Example mod/mod.json
@@ -2,11 +2,11 @@
   "Id": "SMLHelperExampleMod",
   "DisplayName": "Example Mod For SMLHelper",
   "Author": "The SMLHelper Dev Team",
-  "Version": "2.13.5",
+  "Version": "2.14.0.1",
   "Enable": true,
   "AssemblyName": "Example mod.dll",
   "VersionDependencies": {
-    "SMLHelper": "2.13.5"
+    "SMLHelper": "2.14.0"
   },
   "Game": "Both",
   "NitroxCompat": true

--- a/SMLHelper.Tests/PdaItemTests.cs
+++ b/SMLHelper.Tests/PdaItemTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace SMLHelper.Tests.AssestClassTests
 {
+    using System.Reflection;
     using NSubstitute;
     using NUnit.Framework;
     using SMLHelper.V2.Assets;
@@ -38,7 +39,7 @@
             IKnownTechHandler mockKnownTechHandler = Substitute.For<IKnownTechHandler>();
 
             mockTechTypeHandler
-                .AddTechType(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>())
+                .AddTechType(Arg.Any<Assembly>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>())
                 .Returns(createdTechType);
 
             var techData = new TechData();
@@ -58,9 +59,9 @@
 
             // ASSERT
             mockCraftDataHandler.Received(1).SetTechData(createdTechType, techData);
-            mockCraftDataHandler.Received(1).AddToGroup(TechGroup.Cyclops, TechCategory.Cyclops, createdTechType);
+            mockCraftDataHandler.Received(1).AddToGroup(TechGroup.Constructor, TechCategory.Constructor, createdTechType);
             mockKnownTechHandler.DidNotReceiveWithAnyArgs();
-            mockTechTypeHandler.Received(1).AddTechType(Arg.Any<string>(), "classId", "friendlyName", "description", true);
+            mockTechTypeHandler.Received(1).AddTechType(Arg.Any<Assembly>(), "classId", "friendlyName", "description", true);
         }
 
         private class SimpleTestPdaItem : PdaItem
@@ -78,8 +79,8 @@
             {
             }
 
-            public override TechGroup GroupForPDA { get; } = TechGroup.Cyclops;
-            public override TechCategory CategoryForPDA { get; } = TechCategory.Cyclops;
+            public override TechGroup GroupForPDA { get; } = TechGroup.Constructor;
+            public override TechCategory CategoryForPDA { get; } = TechCategory.Constructor;
 
             public override GameObject GetGameObject()
             {

--- a/SMLHelper.Tests/SpawnableTests.cs
+++ b/SMLHelper.Tests/SpawnableTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Reflection;
     using NSubstitute;
     using NUnit.Framework;
     using SMLHelper.V2.Assets;
@@ -56,7 +57,7 @@
             const TechType createdTechType = TechType.Accumulator;
 
             _mockTechTypeHandler
-                .AddTechType(Arg.Any<string>(), Arg.Do<string>((c) => _recordedEvents.Add("AddTechType")), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>())
+                .AddTechType(Arg.Any<Assembly>(), Arg.Do<string>((c) => _recordedEvents.Add("AddTechType")), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>())
                 .Returns(createdTechType);
 
             _mockPrefabHandler.RegisterPrefab(Arg.Do<Spawnable>((s) => _recordedEvents.Add("RegisterPrefab")));
@@ -83,7 +84,7 @@
             // ARRANGE
             const TechType createdTechType = TechType.Accumulator;
 
-            _mockTechTypeHandler.AddTechType(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>())
+            _mockTechTypeHandler.AddTechType(Arg.Any<Assembly>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>())
                                 .Returns(createdTechType);
 
             var customSize = new Vector2int(2, 2);

--- a/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
+++ b/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
@@ -137,6 +137,8 @@ namespace SMLHelper.V2.Handlers
         internal Quaternion Rotation { get; }
         [JsonProperty]
         internal SpawnType Type { get; }
+        [JsonIgnore] 
+        internal Action<GameObject> OnSpawned { get; }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -144,7 +146,16 @@ namespace SMLHelper.V2.Handlers
         /// <param name="techType">TechType to spawn.</param>
         /// <param name="spawnPosition">Position to spawn into.</param>
         public SpawnInfo(TechType techType, Vector3 spawnPosition)
-            : this(default, techType, spawnPosition, Quaternion.identity) { }
+            : this(default, techType, spawnPosition, Quaternion.identity, null) { }
+        
+        /// <summary>
+        /// Initializes a new <see cref="SpawnInfo"/>.
+        /// </summary>
+        /// <param name="techType">TechType to spawn.</param>
+        /// <param name="spawnPosition">Position to spawn into.</param>
+        /// <param name="onSpawned">Delegate to call when the object is successfully spawned.</param>
+        public SpawnInfo(TechType techType, Vector3 spawnPosition, Action<GameObject> onSpawned)
+            : this(default, techType, spawnPosition, Quaternion.identity, onSpawned) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -152,7 +163,16 @@ namespace SMLHelper.V2.Handlers
         /// <param name="classId">ClassID to spawn.</param>
         /// <param name="spawnPosition">Position to spawn into.</param>
         public SpawnInfo(string classId, Vector3 spawnPosition)
-            : this(classId, default, spawnPosition, Quaternion.identity) { }
+            : this(classId, default, spawnPosition, Quaternion.identity, null) { }
+        
+        /// <summary>
+        /// Initializes a new <see cref="SpawnInfo"/>.
+        /// </summary>
+        /// <param name="classId">ClassID to spawn.</param>
+        /// <param name="spawnPosition">Position to spawn into.</param>
+        /// <param name="onSpawned">Delegate to call when the object is successfully spawned.</param>
+        public SpawnInfo(string classId, Vector3 spawnPosition, Action<GameObject> onSpawned)
+            : this(classId, default, spawnPosition, Quaternion.identity, onSpawned) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -161,7 +181,17 @@ namespace SMLHelper.V2.Handlers
         /// <param name="spawnPosition">Position to spawn into.</param>
         /// <param name="rotation">Rotation to spawn at.</param>
         public SpawnInfo(TechType techType, Vector3 spawnPosition, Quaternion rotation)
-            : this(default, techType, spawnPosition, rotation) { }
+            : this(default, techType, spawnPosition, rotation, null) { }
+        
+        /// <summary>
+        /// Initializes a new <see cref="SpawnInfo"/>.
+        /// </summary>
+        /// <param name="techType">TechType to spawn.</param>
+        /// <param name="spawnPosition">Position to spawn into.</param>
+        /// <param name="rotation">Rotation to spawn at.</param>
+        /// <param name="onSpawned">Delegate to call when the object is successfully spawned.</param>
+        public SpawnInfo(TechType techType, Vector3 spawnPosition, Quaternion rotation, Action<GameObject> onSpawned)
+            : this(default, techType, spawnPosition, rotation, onSpawned) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -170,7 +200,17 @@ namespace SMLHelper.V2.Handlers
         /// <param name="spawnPosition">Position to spawn into.</param>
         /// <param name="rotation">Rotation to spawn at.</param>
         public SpawnInfo(string classId, Vector3 spawnPosition, Quaternion rotation)
-            : this(classId, default, spawnPosition, rotation) { }
+            : this(classId, default, spawnPosition, rotation, null) { }
+        
+        /// <summary>
+        /// Initializes a new <see cref="SpawnInfo"/>.
+        /// </summary>
+        /// <param name="classId">ClassID to spawn.</param>
+        /// <param name="spawnPosition">Position to spawn into.</param>
+        /// <param name="rotation">Rotation to spawn at.</param>
+        /// <param name="onSpawned">Delegate to call when the object is successfully spawned.</param>
+        public SpawnInfo(string classId, Vector3 spawnPosition, Quaternion rotation, Action<GameObject> onSpawned)
+            : this(classId, default, spawnPosition, rotation, onSpawned) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -179,7 +219,17 @@ namespace SMLHelper.V2.Handlers
         /// <param name="spawnPosition">Position to spawn into.</param>
         /// <param name="rotation">Rotation to spawn at.</param>
         public SpawnInfo(TechType techType, Vector3 spawnPosition, Vector3 rotation)
-            : this(default, techType, spawnPosition, Quaternion.Euler(rotation)) { }
+            : this(default, techType, spawnPosition, Quaternion.Euler(rotation), null) { }
+
+        /// <summary>
+        /// Initializes a new <see cref="SpawnInfo"/>.
+        /// </summary>
+        /// <param name="techType">TechType to spawn.</param>
+        /// <param name="spawnPosition">Position to spawn into.</param>
+        /// <param name="rotation">Rotation to spawn at.</param>
+        /// <param name="onSpawned">Delegate to call when the object is successfully spawned.</param>
+        public SpawnInfo(TechType techType, Vector3 spawnPosition, Vector3 rotation, Action<GameObject> onSpawned)
+            : this(default, techType, spawnPosition, Quaternion.Euler(rotation), onSpawned) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -188,15 +238,16 @@ namespace SMLHelper.V2.Handlers
         /// <param name="spawnPosition">Position to spawn into.</param>
         /// <param name="rotation">Rotation to spawn at.</param>
         public SpawnInfo(string classId, Vector3 spawnPosition, Vector3 rotation)
-            : this(classId, default, spawnPosition, Quaternion.Euler(rotation)) { }
+            : this(classId, default, spawnPosition, Quaternion.Euler(rotation), null) { }
 
         [JsonConstructor]
-        internal SpawnInfo(string classId, TechType techType, Vector3 spawnPosition, Quaternion rotation)
+        internal SpawnInfo(string classId, TechType techType, Vector3 spawnPosition, Quaternion rotation, Action<GameObject> onSpawned)
         {
             ClassId = classId;
             TechType = techType;
             SpawnPosition = spawnPosition;
             Rotation = rotation;
+            this.OnSpawned = onSpawned;
             Type = TechType switch
             {
                 default(TechType) => SpawnType.ClassId,

--- a/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
+++ b/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
@@ -279,11 +279,11 @@ namespace SMLHelper.V2.Handlers
             unchecked // overflow is fine, just wrap around
             {
                 int hash = 13;
-                hash = (hash * 7) + TechType.GetHashCode();
-                hash = (hash * 7) + ClassId.GetHashCode();
-                hash = (hash * 7) + SpawnPosition.GetHashCode();
-                hash = (hash * 7) + Rotation.GetHashCode();
-                hash = (hash * 7) + Type.GetHashCode();
+                hash += (hash * 7) + TechType.GetHashCode();
+                hash += (hash * 7) + ClassId.GetHashCode();
+                hash += (hash * 7) + SpawnPosition.GetHashCode();
+                hash += (hash * 7) + Rotation.GetHashCode();
+                hash += (hash * 7) + Type.GetHashCode();
                 return hash;
             }
         }

--- a/SMLHelper/MonoBehaviours/EntitySpawner.cs
+++ b/SMLHelper/MonoBehaviours/EntitySpawner.cs
@@ -11,12 +11,12 @@ namespace SMLHelper.V2.MonoBehaviours
     {
         internal SpawnInfo spawnInfo;
 
-        void Start()
+        private IEnumerator Start()
         {
-            StartCoroutine(SpawnAsync());
+            yield return SpawnAsync();
         }
 
-        IEnumerator SpawnAsync()
+        private IEnumerator SpawnAsync()
         {
             var stringToLog = spawnInfo.Type switch
             {
@@ -57,13 +57,15 @@ namespace SMLHelper.V2.MonoBehaviours
             lw.streamer.cellManager.RegisterEntity(obj);
 
             obj.SetActive(true);
+            
+            spawnInfo.OnSpawned?.Invoke(obj);
 
             LargeWorldStreamerPatcher.savedSpawnInfos.Add(spawnInfo);
 
             Destroy(gameObject);
         }
 
-        IEnumerator GetPrefabAsync(IOut<GameObject> gameObject)
+        private IEnumerator GetPrefabAsync(IOut<GameObject> gameObject)
         {
             GameObject obj;
 

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.13.5")]
-[assembly: AssemblyFileVersion("2.13.5")]
+[assembly: AssemblyVersion("2.14.0.1")]
+[assembly: AssemblyFileVersion("2.14.0.1")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
   "Id": "SMLHelper",
   "DisplayName": "SMLHelper",
   "Author": "The SMLHelper Dev Team",
-  "Version": "2.13.5",
+  "Version": "2.14.0.1",
   "Enable": true,
   "Game": "BelowZero",
   "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,7 +2,7 @@
   "Id": "SMLHelper",
   "DisplayName": "SMLHelper",
   "Author": "The SMLHelper Dev Team",
-  "Version": "2.14.0.1",
+  "Version": "2.14.0.2",
   "Enable": true,
   "Game": "BelowZero",
   "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
   "Id": "SMLHelper",
   "DisplayName": "SMLHelper",
   "Author": "The SMLHelper Dev Team",
-  "Version": "2.14.0.1",
+  "Version": "2.14.0.2",
   "Enable": true,
   "Game": "Subnautica",
   "AssemblyName": "SMLHelper.dll",

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,7 +2,7 @@
   "Id": "SMLHelper",
   "DisplayName": "SMLHelper",
   "Author": "The SMLHelper Dev Team",
-  "Version": "2.13.5",
+  "Version": "2.14.0.1",
   "Enable": true,
   "Game": "Subnautica",
   "AssemblyName": "SMLHelper.dll",


### PR DESCRIPTION
### Changes made in this pull request

  - Added a few overloads to `SpawnInfo` for on-spawned callbacks.
  
These callbacks will only be called once and the first time the object is spawned in the world. Purpose of this feature is to merely modify a few properties for vanilla objects whom are spawned using the `CoordinatedSpawns` system.

**Builds:**
[SMLHelper_SN.STABLE.zip](https://github.com/SubnauticaModding/SMLHelper/files/8578361/SMLHelper_SN.STABLE.zip)
[SMLHelper_BZ.STABLE.zip](https://github.com/SubnauticaModding/SMLHelper/files/8578362/SMLHelper_BZ.STABLE.zip)