### PR TITLE
Bugfixes for controllers.

### DIFF
--- a/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
+++ b/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
@@ -202,7 +202,8 @@
         private void BuildModKeybindOption(string id, string label, MemberInfoMetadata<T> memberInfoMetadata)
         {
             KeyCode value = memberInfoMetadata.GetValue<KeyCode>(ConfigFileMetadata.Config);
-            AddKeybindOption(id, label, GameInput.Device.Keyboard, value);
+            GameInput.Device primaryDevice = GameInput.IsPrimaryDeviceGamepad() ? GameInput.Device.Controller : GameInput.Device.Keyboard;
+            AddKeybindOption(id, label, primaryDevice, value);
         }
 
         /// <summary>

--- a/SMLHelper/Patchers/OptionsPanelPatcher.cs
+++ b/SMLHelper/Patchers/OptionsPanelPatcher.cs
@@ -184,7 +184,8 @@
                 public static void store(string name, HeadingState state) => statesConfig[name] = state;
             }
 
-            // we add arrow button from Choice ui element to the options headings for collapsing/expanding 
+            // we add arrow button from Choice ui element to the options headings for collapsing/expanding
+            // it cannot be activated by controller since there are only click handlers
             private static void InitHeadingPrefab(uGUI_TabbedControlsPanel panel)
             {
                 if (headingPrefab)
@@ -214,7 +215,8 @@
 
 #region components
             // main component for headings toggling
-            private class HeadingToggle: MonoBehaviour
+            // extending Selectable allows controllers to bypass headings
+            private class HeadingToggle: Selectable
             {
                 private HeadingState headingState = HeadingState.Expanded;
                 private string headingName = null;


### PR DESCRIPTION
Fix https://github.com/SubnauticaModding/SMLHelper/issues/263

### Changes made in this pull request

  - When KeyBinds are created use either controller OR keyboard instead of always keyboard.
     - Ideally these could be changed after the options are rendered based on your last input, but I couldn't figure out how to do that
  - Changed HeadingToggle to extend Selectable instead of Monobehaviour.
     This allows you to "select" headings but they don't get a selected background color and you can't toggle them, however you CAN get into the options with a controller now. They can still be toggled by mouse click.


FYI I found out sliders can't be activated by controller. 😂
not as important as the keybinds though since you can still change them with mouse.