### PR TITLE
Remove extra EventHandler on Button

### DIFF
--- a/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
+++ b/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
@@ -40,7 +40,6 @@
             ConfigFileMetadata.BindEvents();
 
             ButtonClicked += EventHandler;
-            ButtonClicked += EventHandler;
             ChoiceChanged += EventHandler;
             KeybindChanged += EventHandler;
             SliderChanged += EventHandler;


### PR DESCRIPTION
### Changes made in this pull request

- Removed extra EventHandler when you click button in the Config menu. This caused it to run your method twice.

Simple example:
```
        [Button("Reset Keybinds")]
        public void ResetKeybinds()
        {
            Logger.Log(Logger.Level.Debug, "Clicked reset keybinds.");
        }
```
output 👇 
![image](https://user-images.githubusercontent.com/6541615/168445782-a39c930f-7d47-4d6f-ac99-ba9b29320038.png)
