### PR TITLE
Allow mod options menus to provide tooltip language IDs, similar to label language IDs.

### DIFF
--- a/SMLHelper/Options/Attributes/ConfigFileMetadata.cs
+++ b/SMLHelper/Options/Attributes/ConfigFileMetadata.cs
@@ -467,7 +467,7 @@
         }
 
         /// <summary>
-        /// Generates tooltips for each <see cref="ModOption"/> with a specified <see cref="TooltipAttribute"/>, before
+        /// Generates tooltips as required for each <see cref="ModOption"/>, before
         /// invoking any relevant method(s) specified with <see cref="OnGameObjectCreatedAttribute"/>(s) and passes
         /// parameters when a <see cref="GameObject"/> is created in the options menu.
         /// </summary>
@@ -477,8 +477,14 @@
         {
             if (TryGetMetadata(e.Id, out ModOptionAttributeMetadata<T> modOptionMetadata))
             {
-                // Create a tooltip if there is a TooltipAttribute specified
-                if (modOptionMetadata.ModOptionAttribute.Tooltip is string tooltip)
+                string tooltip = Language.main.TryGet(modOptionMetadata.ModOptionAttribute.TooltipLanguageId, out string languageTooltip) switch
+                {
+                    true => languageTooltip,
+                    false => modOptionMetadata.ModOptionAttribute.Tooltip
+                };
+
+                // Create a tooltip if specified
+                if (tooltip is not null)
                 {
                     e.GameObject.GetComponentInChildren<Text>().gameObject.AddComponent<ModOptionTooltip>().Tooltip = tooltip;
                 }

--- a/SMLHelper/Options/Attributes/ModOptionAttribute.cs
+++ b/SMLHelper/Options/Attributes/ModOptionAttribute.cs
@@ -34,7 +34,7 @@
         private static int i = 0;
 
         /// <summary>
-        /// An optional tooltip to display for the field.
+        /// An optional tooltip to display for the field. If <see cref="TooltipLanguageId"/> is set, this will be ignored.
         /// </summary>
         public string Tooltip { get; set; }
 
@@ -45,6 +45,12 @@
         /// <seealso cref="LanguageHandler.SetLanguageLine(string, string)"/>
         /// <seealso cref="Language.Get(string)"/>
         public string LabelLanguageId { get; set; }
+
+        /// <summary>
+        /// An optional id to be parsed with <see cref="Language.Get(string)"/> for the tooltip, allowing for custom lanaguage-based strings
+        /// via the <see cref="LanguageHandler"/> API. If this is set, it will take precedence.
+        /// </summary>
+        public string TooltipLanguageId { get; set; }
 
         /// <summary>
         /// Signifies the decorated member should be represented in the mod's options menu as a <see cref="ModOption"/>


### PR DESCRIPTION
## Changes made in this pull request
- Allows modders to specify a `TooltipLanguageId` property, for their config attributes, meaning they can use SMLHelper's Language handler for specifying the tooltips instead of a compile-time constant. Works similarly to the `LabelLanguageId` property.