### PR TITLE
Converted Projects To .NET SDK

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -17,4 +17,6 @@ To create your own publicized DLLs, install the [BepinEx Plugin](https://github.
 
 Copy these DLLs into the `Dependencies` folder of SMLHelper so you can build it. Publicized version of the assemblies should make you able to call non-public members without reflection.
 
+- As of version 2.14, SMLHelper developers are required to have .NET 6 installed for the project to build.
+
 Then, load up the solution, make your edits, then create your Pull Request!

--- a/Example mod/Example mod.csproj
+++ b/Example mod/Example mod.csproj
@@ -1,71 +1,39 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">SN.STABLE</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C8FB0981-77D2-47C7-BBEF-A3A9EBACACBF}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <TargetFramework>net472</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <RootNamespace>Example_mod</RootNamespace>
     <AssemblyName>Example mod</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SN.STABLE|AnyCPU'">
-    <OutputPath>bin\SN.STABLE\</OutputPath>
-    <DefineConstants>SUBNAUTICA;SUBNAUTICA_STABLE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>8.0</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>
-    </DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>latest</LangVersion>
+    <Configurations>SN.STABLE;BZ.EXP;SN.EXP;BZ.STABLE</Configurations>
+    <Platforms>AnyCPU</Platforms>
+    <Copyright>Copyright ©  2019</Copyright>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+  <Import Project="$(SolutionDir)Version.targets" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SN.STABLE|AnyCPU'">
+    <OutputPath>bin\SN.STABLE\</OutputPath>
+    <DefineConstants>SUBNAUTICA;SUBNAUTICA_STABLE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SN.EXP|AnyCPU'">
     <OutputPath>bin\SN.EXP\</OutputPath>
     <DefineConstants>SUBNAUTICA;SUBNAUTICA_EXP</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>8.0</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>
-    </DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'BZ.STABLE|AnyCPU'">
     <OutputPath>bin\BZ.STABLE\</OutputPath>
     <DefineConstants>BELOWZERO;BELOWZERO_STABLE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>8.0</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>
-    </DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'BZ.EXP|AnyCPU'">
     <OutputPath>bin\BZ.EXP\</OutputPath>
     <DefineConstants>BELOWZERO;BELOWZERO_EXP</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>8.0</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>
-    </DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
@@ -88,8 +56,6 @@
       <HintPath>..\SMLHelper\bin\$(Configuration)\SMLHelper.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(Dependencies)\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
@@ -100,13 +66,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Mod.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="mod.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Example mod/Example mod.csproj
+++ b/Example mod/Example mod.csproj
@@ -52,10 +52,6 @@
       <HintPath>$(Dependencies)\QModInstaller.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="SMLHelper">
-      <HintPath>..\SMLHelper\bin\$(Configuration)\SMLHelper.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(Dependencies)\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
@@ -64,6 +60,7 @@
       <HintPath>$(Dependencies)\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <ProjectReference Include="..\SMLHelper\SMLHelper.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="mod.json">

--- a/Example mod/Properties/AssemblyInfo.cs
+++ b/Example mod/Properties/AssemblyInfo.cs
@@ -1,18 +1,5 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Example mod")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Example mod")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
@@ -21,16 +8,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c8fb0981-77d2-47c7-bbef-a3a9ebacacbf")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.14.0")]
-[assembly: AssemblyFileVersion("2.14.0")]

--- a/PostBuild.targets
+++ b/PostBuild.targets
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+        <PowerShell>powershell.exe</PowerShell>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(OS)' == 'Unix'">
+        <PowerShell>pwsh</PowerShell>
+    </PropertyGroup>
+    <Target Name="ZipFiles" AfterTargets="PostBuildEvent">
+        <Exec
+                Command="$(PowerShell) -ExecutionPolicy Bypass -NoProfile -NonInteractive -File $(SolutionDir)Scripts/SMLHelper-post-build.ps1 -SolutionDir $(SolutionDir) -ConfigurationName $(ConfigurationName) -TargetDir $(OutDir) -ProjectDir $(ProjectDir)" 
+        />
+    </Target>
+</Project>

--- a/SMLHelper.Tests/SMLHelper.Tests.csproj
+++ b/SMLHelper.Tests/SMLHelper.Tests.csproj
@@ -58,10 +58,6 @@
       <HintPath>$(Dependencies)\Assembly-CSharp_publicized.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="SMLHelper">
-      <HintPath>..\SMLHelper\bin\$(Configuration)\SMLHelper.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
@@ -92,6 +88,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SMLHelper\SMLHelper.csproj">
+      <Project>{418502dd-372d-4ef9-8021-b262552dfede}</Project>
+      <Name>SMLHelper</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -1,18 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("SMLHelper")]
-[assembly: AssemblyDescription("A library that helps making mods for Subnautica easier.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("SMLHelperDevs")]
-[assembly: AssemblyProduct("SMLHelper")]
-[assembly: AssemblyCopyright("Copyright © 2019")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
@@ -22,17 +9,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("418502dd-372d-4ef9-8021-b262552dfede")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.14.0")]
-[assembly: AssemblyFileVersion("2.14.0")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -1,70 +1,44 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.props" />
   <PropertyGroup>
-    <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
-    <Configuration Condition=" '$(Configuration)' == '' ">SN.STABLE</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{418502DD-372D-4EF9-8021-B262552DFEDE}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFramework>net472</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <RootNamespace>SMLHelper.V2</RootNamespace>
     <AssemblyName>SMLHelper</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <Configurations>SN.STABLE;BZ.STABLE;SN.EXP;BZ.EXP</Configurations>
+    <Platforms>AnyCPU</Platforms>
+    <Copyright>Copyright @ 2019</Copyright>
+    <Authors>SMLHelperDevs</Authors>
+    <Description>A library that helps making mods for Subnautica easier.</Description>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>None</DebugType>
   </PropertyGroup>
-  <PropertyGroup>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
+  <Import Project="$(SolutionDir)Version.targets" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SN.STABLE|AnyCPU'">
     <OutputPath>bin\SN.STABLE\</OutputPath>
     <DefineConstants>SUBNAUTICA;SUBNAUTICA_STABLE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\SN.STABLE\SMLHelper.xml</DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SN.EXP|AnyCPU'">
     <OutputPath>bin\SN.EXP\</OutputPath>
     <DefineConstants>SUBNAUTICA;SUBNAUTICA_EXP</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\SN.EXP\SMLHelper.xml</DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'BZ.STABLE|AnyCPU'">
     <OutputPath>bin\BZ.STABLE\</OutputPath>
     <DefineConstants>BELOWZERO;BELOWZERO_STABLE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\BZ.STABLE\SMLHelper.xml</DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'BZ.EXP|AnyCPU'">
     <OutputPath>bin\BZ.EXP\</OutputPath>
     <DefineConstants>BELOWZERO;BELOWZERO_EXP</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\BZ.EXP\SMLHelper.xml</DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
@@ -87,8 +61,6 @@
       <HintPath>$(Dependencies)\QModInstaller.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="UnityEngine">
       <HintPath>$(Dependencies)\UnityEngine.dll</HintPath>
       <Private>False</Private>
@@ -131,207 +103,11 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Assets\Buildable.cs" />
-    <Compile Include="Assets\Craftable.cs" />
-    <Compile Include="Assets\CustomFabricator.cs" />
-    <Compile Include="Assets\Equipable.cs" />
-    <Compile Include="Assets\Fish.cs" />
-    <Compile Include="Assets\FishPrefab.cs" />
-    <Compile Include="Assets\ModPrefab.cs" />
-    <Compile Include="Assets\ModPrefabCache.cs" />
-    <Compile Include="Assets\ModPrefabRequest.cs" />
-    <Compile Include="Assets\SubnauticaModSprite.cs" />
-    <Compile Include="Assets\BelowZeroModSprite.cs" />
-    <Compile Include="Assets\PdaItem.cs" />
-    <Compile Include="Assets\Spawnable.cs" />
-    <Compile Include="Commands\Parameter.cs" />
-    <Compile Include="Commands\ConsoleCommand.cs" />
-    <Compile Include="Crafting\CraftingNode.cs" />
-    <Compile Include="Crafting\ModCraftTreeCraft.cs" />
-    <Compile Include="Crafting\ModCraftTreeLinkingNode.cs" />
-    <Compile Include="Crafting\ModCraftTreeNode.cs" />
-    <Compile Include="Crafting\ModCraftTreeRoot.cs" />
-    <Compile Include="Crafting\ModCraftTreeTab.cs" />
-    <Compile Include="Crafting\Node.cs" />
-    <Compile Include="Crafting\TabNode.cs" />
-    <Compile Include="Crafting\RecipeData.cs" />
-    <Compile Include="Crafting\TechData.cs" />
-    <Compile Include="Commands\ConsoleCommandAttribute.cs" />
-    <Compile Include="FMod\Interfaces\IFModSound.cs" />
-    <Compile Include="FMod\FModMultiSounds.cs" />
-    <Compile Include="Handlers\BackgroundTypeHandler.cs" />
-    <Compile Include="Handlers\CoordinatedSpawnsHandler.cs" />
-    <Compile Include="Handlers\CustomSoundHandler.cs" />
-    <Compile Include="Handlers\EatableHandler.cs" />
-    <Compile Include="Handlers\EquipmentHandler.cs" />
-    <Compile Include="Handlers\PDALogHandler.cs" />
-    <Compile Include="Handlers\PingHandler.cs" />
-    <Compile Include="Handlers\SaveDataHandler.cs" />
-    <Compile Include="Handlers\SurvivalHandler.cs" />
-    <Compile Include="Handlers\TechCategoryHandler.cs" />
-    <Compile Include="Handlers\TechGroupHandler.cs" />
-    <Compile Include="Interfaces\IBackgroundTypeHandler.cs" />
-    <Compile Include="Interfaces\ICoordinatedSpawnHandler.cs" />
-    <Compile Include="Interfaces\ICustomSoundHandler.cs" />
-    <Compile Include="Interfaces\IEatableHandler.cs" />
-    <Compile Include="Interfaces\IModOptionAttribute.cs" />
-    <Compile Include="Interfaces\IModOptionEventAttribute.cs" />
-    <Compile Include="Interfaces\IConsoleCommandHandler.cs" />
-    <Compile Include="Interfaces\IEquipmentHandler.cs" />
-    <Compile Include="Interfaces\IPDALogHandler.cs" />
-    <Compile Include="Interfaces\IPingHandler.cs" />
-    <Compile Include="Interfaces\ISaveDataHandler.cs" />
-    <Compile Include="Interfaces\ISurvivalHandler.cs" />
-    <Compile Include="Interfaces\ITechCategoryHandler.cs" />
-    <Compile Include="Interfaces\ITechGroupHandler.cs" />
-    <Compile Include="Json\Attributes\FileNameAttribute.cs" />
-    <Compile Include="Json\ConfigFileAttribute.cs" />
-    <Compile Include="Json\ConfigFileEventArgs.cs" />
-    <Compile Include="Json\Converters\FloatConverter.cs" />
-    <Compile Include="Json\Converters\QuaternionConverter.cs" />
-    <Compile Include="Json\Converters\Vector2Converter.cs" />
-    <Compile Include="Json\Converters\Vector2IntConverter.cs" />
-    <Compile Include="Json\Converters\Vector3Converter.cs" />
-    <Compile Include="Json\Converters\Vector3IntConverter.cs" />
-    <Compile Include="Json\Converters\Vector4Converter.cs" />
-    <Compile Include="Json\ExtensionMethods\JsonExtensions.cs" />
-    <Compile Include="Handler.cs" />
-    <Compile Include="Handlers\BioReactorHandler.cs" />
-    <Compile Include="Handlers\CraftDataHandler.cs" />
-    <Compile Include="Handlers\CraftDataHandler_Subnautica.cs" />
-    <Compile Include="Handlers\CraftDataHandler_BelowZero.cs" />
-    <Compile Include="Handlers\CraftTreeHandler.cs" />
-    <Compile Include="Handlers\FishHandler.cs" />
-    <Compile Include="Handlers\IngameMenuHandler.cs" />
-    <Compile Include="Handlers\ItemActionHandler.cs" />
-    <Compile Include="Handlers\KnownTechHandler.cs" />
-    <Compile Include="Handlers\LanguageHandler.cs" />
-    <Compile Include="Handlers\LootDistributionHandler.cs" />
-    <Compile Include="Handlers\OptionsPanelHandler.cs" />
-    <Compile Include="Handlers\PDAEncyclopediaHandler.cs" />
-    <Compile Include="Handlers\PDAHandler.cs" />
-    <Compile Include="Handlers\PrefabHandler.cs" />
-    <Compile Include="Handlers\SpriteHandler.cs" />
-    <Compile Include="Handlers\TechTypeHandler.cs" />
-    <Compile Include="Handlers\WorldEntityDatabaseHandler.cs" />
-    <Compile Include="Initializer.cs" />
-    <Compile Include="Interfaces\IBioReactorHandler.cs" />
-    <Compile Include="Interfaces\ICraftDataHandler.cs" />
-    <Compile Include="Interfaces\ICraftDataHandler_BelowZero.cs" />
-    <Compile Include="Interfaces\ICraftDataHandler_Subnautica.cs" />
-    <Compile Include="Interfaces\ICraftTreeHandler.cs" />
-    <Compile Include="Interfaces\IFishHandler.cs" />
-    <Compile Include="Interfaces\IIngameMenuHandler.cs" />
-    <Compile Include="Interfaces\IItemActionHandler.cs" />
-    <Compile Include="Json\Interfaces\IJsonFile.cs" />
-    <Compile Include="Interfaces\IKnownTechHandler.cs" />
-    <Compile Include="Interfaces\ILanguageHandler.cs" />
-    <Compile Include="Interfaces\ILootDistributionHandler.cs" />
-    <Compile Include="Interfaces\IOptionsPanelHandler.cs" />
-    <Compile Include="Interfaces\IPDAEncyclopediaHandler.cs" />
-    <Compile Include="Interfaces\IPDAHandler.cs" />
-    <Compile Include="Interfaces\IPrefabHandler.cs" />
-    <Compile Include="Interfaces\ISpriteHandler.cs" />
-    <Compile Include="Interfaces\IStorageHelper.cs" />
-    <Compile Include="Interfaces\ITechTypeHandler.cs" />
-    <Compile Include="Interfaces\ITechTypeHandlerInternal.cs" />
-    <Compile Include="Interfaces\IWorldEntityDatabaseHandler.cs" />
-    <Compile Include="Json\JsonFile.cs" />
-    <Compile Include="Json\JsonFileEventArgs.cs" />
-    <Compile Include="Json\SaveDataCache.cs" />
-    <Compile Include="Logger.cs" />
-    <Compile Include="MonoBehaviours\EntitySpawner.cs" />
-    <Compile Include="MonoBehaviours\Fixer.cs" />
-    <Compile Include="Options\Attributes\ConfigFileMetadata.cs" />
-    <Compile Include="Options\Attributes\MemberInfoMetadata.cs" />
-    <Compile Include="Options\Attributes\ModOptionAttributeMetadata.cs" />
-    <Compile Include="Options\ButtonModOption.cs" />
-    <Compile Include="Options\Attributes\ChoiceAttribute.cs" />
-    <Compile Include="Options\ChoiceModOption.cs" />
-    <Compile Include="Json\ConfigFile.cs" />
-    <Compile Include="Options\Attributes\OptionsMenuBuilder.cs" />
-    <Compile Include="Options\Attributes\IgnoreMemberAttribute.cs" />
-    <Compile Include="Interfaces\IModOptionEventArgs.cs" />
-    <Compile Include="Options\Attributes\KeybindAttribute.cs" />
-    <Compile Include="Options\KeybindModOption.cs" />
-    <Compile Include="Options\Attributes\ModOptionAttribute.cs" />
-    <Compile Include="Options\Attributes\ModOptionEventAttribute.cs" />
-    <Compile Include="Options\ModOptions.cs" />
-    <Compile Include="Options\Attributes\MenuAttribute.cs" />
-    <Compile Include="Options\Attributes\ButtonAttribute.cs" />
-    <Compile Include="Options\Attributes\OnGameObjectCreatedAttribute.cs" />
-    <Compile Include="Options\Attributes\SliderAttribute.cs" />
-    <Compile Include="Options\SliderModOption.cs" />
-    <Compile Include="Options\Attributes\OnChangeAttribute.cs" />
-    <Compile Include="Options\Attributes\ToggleAttribute.cs" />
-    <Compile Include="Options\ToggleModOption.cs" />
-    <Compile Include="Options\ModOptionTooltip.cs" />
-    <Compile Include="Options\Utility\Validator.cs" />
-    <Compile Include="Patchers\CustomSoundPatcher.cs" />
-    <Compile Include="Patchers\EatablePatcher.cs" />
-    <Compile Include="Patchers\EnumPatching\BackgroundTypePatcher.cs" />
-    <Compile Include="Patchers\BioReactorPatcher.cs" />
-    <Compile Include="Handlers\ConsoleCommandsHandler.cs" />
-    <Compile Include="Patchers\ConsoleCommandsPatcher.cs" />
-    <Compile Include="Patchers\CraftDataPatcher.cs" />
-    <Compile Include="Patchers\CraftDataPatcher_BelowZero.cs" />
-    <Compile Include="Patchers\CraftDataPatcher_Subnautica.cs" />
-    <Compile Include="Patchers\CraftTreePatcher.cs" />
-    <Compile Include="Patchers\EnumPatching\CraftTreeTypePatcher.cs" />
-    <Compile Include="Patchers\EnumPatching\EnumPatcher.cs" />
-    <Compile Include="Patchers\EnumPatching\EquipmentTypePatcher.cs" />
-    <Compile Include="Patchers\EnumPatching\TechCategoryPatcher.cs" />
-    <Compile Include="Patchers\EnumPatching\TechGroupPatcher.cs" />
-    <Compile Include="Patchers\FishPatcher.cs" />
-    <Compile Include="Patchers\IngameMenuPatcher.cs" />
-    <Compile Include="Patchers\ItemActionPatcher.cs" />
-    <Compile Include="Patchers\ItemsContainerPatcher.cs" />
-    <Compile Include="Patchers\KnownTechPatcher.cs" />
-    <Compile Include="Patchers\LanguagePatcher.cs" />
-    <Compile Include="Patchers\LargeWorldStreamerPatcher.cs" />
-    <Compile Include="Patchers\LootDistributionPatcher.cs" />
-    <Compile Include="Patchers\OptionsPanelPatcher.cs" />
-    <Compile Include="Patchers\PDAEncyclopediaPatcher.cs" />
-    <Compile Include="Patchers\PDALogPatcher.cs" />
-    <Compile Include="Patchers\PDAPatcher.cs" />
-    <Compile Include="Patchers\EnumPatching\PingTypePatcher.cs" />
-    <Compile Include="Patchers\PrefabDatabasePatcher.cs" />
-    <Compile Include="Patchers\SpritePatcher.cs" />
-    <Compile Include="Patchers\EnumPatching\TechTypePatcher.cs" />
-    <Compile Include="Patchers\SurvivalPatcher.cs" />
-    <Compile Include="Patchers\TooltipPatcher.cs" />
-    <Compile Include="Patchers\WorldEntityDatabasePatcher.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Utility\AudioUtils.cs" />
-    <Compile Include="Utility\AudioUtils_BelowZero.cs" />
-    <Compile Include="Utility\AudioUtils_Subnautica.cs" />
-    <Compile Include="Utility\BasicText.cs" />
-    <Compile Include="Utility\EnumCacheManager.cs" />
-    <Compile Include="Utility\ExtBannedIdManager.cs" />
-    <Compile Include="Interfaces\IBasicText.cs" />
-    <Compile Include="Utility\ImageUtils.cs" />
-    <Compile Include="Utility\IOUtilities.cs" />
-    <Compile Include="Utility\ItemStorageHelper.cs" />
-    <Compile Include="Json\Converters\KeyCodeConverter.cs" />
-    <Compile Include="Utility\JsonUtils.cs" />
-    <Compile Include="Utility\KeyCodeUtils.cs" />
-    <Compile Include="Utility\PatchUtils.cs" />
-    <Compile Include="Utility\PlayerPrefsExtra.cs" />
-    <Compile Include="Utility\Polyfill.cs" />
-    <Compile Include="Utility\PrefabUtils.cs" />
-    <Compile Include="Utility\ReflectionHelper.cs" />
-    <Compile Include="Utility\SaveUtils.cs" />
-    <Compile Include="Utility\SelfCheckingDictionary.cs" />
-    <Compile Include="Utility\SoundChannel.cs" />
-    <Compile Include="Utility\StorageHelperExtensions.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="mod_Subnautica.json" Condition="$(Configuration.Contains('SN.'))" />
     <None Include="mod_BelowZero.json" Condition="$(Configuration.Contains('BZ.'))" />
-    <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File "$(SolutionDir)Scripts\SMLHelper-post-build.ps1" -SolutionDir $(SolutionDir) -ConfigurationName $(ConfigurationName) -TargetDir $(TargetDir) -ProjectDir $(ProjectDir)</PostBuildEvent>
-  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="7-Zip.CommandLine" Version="18.1.0" />
+  </ItemGroup>
+  <Import Project="$(SolutionDir)PostBuild.targets" />
 </Project>

--- a/Scripts/SMLHelper-post-build.ps1
+++ b/Scripts/SMLHelper-post-build.ps1
@@ -32,7 +32,7 @@ function Zip
     if ($Fresh -and (Test-Path $DestinationPath)) {
         $null = Remove-Item -Path $DestinationPath
     }
-
+    
     $7ZipPath = [System.IO.Path]::Combine($SolutionDir, "packages", "7-Zip.CommandLine.18.1.0", "tools", "7za.exe")
     if (Test-Path $7ZipPath)
     {   # Use 7Zip if available
@@ -50,7 +50,6 @@ function Zip
         }
     }
 }
-
 # Copy correct mod.json to target dir
 $modJsonSuffix = switch ($ConfigurationName.ToUpper())
 {

--- a/Version.targets
+++ b/Version.targets
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <!-- The assembly uses this version number. !-->
+        <Version>2.14.0</Version>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
### Changes made in this pull request

  - Converted both ExampleMod and SMLHelper projects to .NET SDK template

The .NET framework msbuild template is now legacy and deprecated, and very hard to work with outside of Windows.
Using the .NET SDK template, while having all of .NET 6 features (outside of the compiler, of course), we can still target .NET Framework 4.7.2 for the build so it is completely backward compatible.

I've tested this on Linux and it works perfectly. I need somebody else to just build the project on Windows to confirm i didn't miss anything.

**Requires .NET 6 to be installed.**