### PR TITLE
added MakeEatable method and pickupable patch

### DIFF
--- a/SMLHelper/Handlers/EatableHandler.cs
+++ b/SMLHelper/Handlers/EatableHandler.cs
@@ -28,6 +28,15 @@
                 decomposes = decomposes,
             });
         }
+        void IEatableHandler.MakeEatable(TechType item, float food, float water, bool decomposes)
+        {
+            PickupablePatcher.AddedEatables.Add(item, new EditedEatableValues()
+            {
+                food = food,
+                water = water,
+                decomposes = decomposes,
+            });
+        }
         /// <summary>
         /// Use this to change the values of a specific TechType.
         /// </summary>
@@ -39,7 +48,17 @@
         {
             Main.ModifyEatable(item, food, water, decomposes);
         }
-
+        /// <summary>
+        /// Use this to change the values of a specific TechType.
+        /// </summary>
+        /// <param name="item">The TechType of the item you want to change.</param>
+        /// <param name="food">The food value you want to change it to.</param>
+        /// <param name="water">The water value you want to change it to.</param>
+        /// <param name="decomposes">Whether or not the item decomposes over time</param>
+        public static void MakeEatable(TechType item, float food, float water, bool decomposes = true)
+        {
+            Main.MakeEatable(item, food, water, decomposes);
+        }
 #elif BELOWZERO 
         void IEatableHandler.ModifyEatable(TechType item, float food, float water, bool decomposes, float health, float coldValue, int maxCharges)
         {
@@ -48,11 +67,21 @@
                 food = food,
                 water = water,
                 decomposes = decomposes,
-#if BELOWZERO
                 health = health,
                 maxCharges = maxCharges,
                 coldValue = coldValue
-#endif
+            });
+        }
+        void IEatableHandler.MakeEatable(TechType item, float food, float water, bool decomposes, float health, float coldValue, int maxCharges)
+        {
+            PickupablePatcher.AddedEatables.Add(item, new EditedEatableValues()
+            {
+                food = food,
+                water = water,
+                decomposes = decomposes,
+                health = health,
+                maxCharges = maxCharges,
+                coldValue = coldValue
             });
         }
 
@@ -70,6 +99,21 @@
         public static void ModifyEatable(TechType item, float food, float water, bool decomposes = true, float health = 0f, float coldValue = 0f, int maxCharges = 0)
         {
             Main.ModifyEatable(item, food, water, decomposes, health, coldValue, maxCharges);
+        }
+        /// <summary>
+        /// Use this to change the values of a specific TechType
+        /// </summary>
+        /// <param name="item">the techtype of the item you want to change</param>
+        /// <param name="food">the food value you want to change it to</param>
+        /// <param name="water">the water value you want to change it to</param>
+        /// <param name="decomposes">whether or not the item decomposes over time</param>
+        /// <param name="health">how much you want to set the health gained from eating this item to</param>
+        /// <param name="coldValue">How much eating this item changes the current cold meter value.<br/>
+        /// Negative values heats up the player while positive values makes the player colder.</param>
+        /// <param name="maxCharges">how many times the item can be used before being consumed</param>
+        public static void MakeEatable(TechType item, float food, float water, bool decomposes = true, float health = 0f, float coldValue = 0f, int maxCharges = 0)
+        {
+            Main.MakeEatable(item, food, water, decomposes, health, coldValue, maxCharges);
         }
 #endif
         internal class EditedEatableValues

--- a/SMLHelper/Handlers/EatableHandler.cs
+++ b/SMLHelper/Handlers/EatableHandler.cs
@@ -8,6 +8,7 @@
     /// </summary>
     public class EatableHandler : IEatableHandler
     {
+        private static bool pickupablePatched = false;
         /// <summary>
         /// Main entry point for all calls to this handler.
         /// </summary>
@@ -30,6 +31,9 @@
         }
         void IEatableHandler.MakeEatable(TechType item, float food, float water, bool decomposes)
         {
+            if(!pickupablePatched)
+                PickupablePatcher.Patch(Initializer.harmony);
+
             PickupablePatcher.AddedEatables.Add(item, new EditedEatableValues()
             {
                 food = food,
@@ -49,9 +53,9 @@
             Main.ModifyEatable(item, food, water, decomposes);
         }
         /// <summary>
-        /// Use this to change the values of a specific TechType.
+        /// Allows you to make an item that isn't normally edible edible, with specific values
         /// </summary>
-        /// <param name="item">The TechType of the item you want to change.</param>
+        /// <param name="item">The TechType of the item you wish to make edible.</param>
         /// <param name="food">The food value you want to change it to.</param>
         /// <param name="water">The water value you want to change it to.</param>
         /// <param name="decomposes">Whether or not the item decomposes over time</param>
@@ -74,6 +78,9 @@
         }
         void IEatableHandler.MakeEatable(TechType item, float food, float water, bool decomposes, float health, float coldValue, int maxCharges)
         {
+            if(!pickupablePatched)
+                PickupablePatcher.Patch(Initializer.harmony);
+
             PickupablePatcher.AddedEatables.Add(item, new EditedEatableValues()
             {
                 food = food,
@@ -101,9 +108,9 @@
             Main.ModifyEatable(item, food, water, decomposes, health, coldValue, maxCharges);
         }
         /// <summary>
-        /// Use this to change the values of a specific TechType
+        /// Allows you to make an item that isn't normally edible edible, with specific values
         /// </summary>
-        /// <param name="item">the techtype of the item you want to change</param>
+        /// <param name="item">The TechType of the item you wish to make edible.</param>
         /// <param name="food">the food value you want to change it to</param>
         /// <param name="water">the water value you want to change it to</param>
         /// <param name="decomposes">whether or not the item decomposes over time</param>

--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -79,12 +79,7 @@
             TooltipPatcher.Patch(harmony);
             SurvivalPatcher.Patch(harmony);
             CustomSoundPatcher.Patch(harmony);
-
-            if (PickupablePatcher.AddedEatables.Count > 0)
-                PickupablePatcher.Patch(harmony);
-            else
-                EatablePatcher.Patch(harmony);
-
+            EatablePatcher.Patch(harmony);
 
             Logger.Debug("Saving TechType Cache");
             TechTypePatcher.cacheManager.SaveCache();

--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -79,7 +79,11 @@
             TooltipPatcher.Patch(harmony);
             SurvivalPatcher.Patch(harmony);
             CustomSoundPatcher.Patch(harmony);
-            EatablePatcher.Patch(harmony);
+
+            if (PickupablePatcher.AddedEatables.Count > 0)
+                PickupablePatcher.Patch(harmony);
+            else
+                EatablePatcher.Patch(harmony);
 
 
             Logger.Debug("Saving TechType Cache");

--- a/SMLHelper/Interfaces/IEatableHandler.cs
+++ b/SMLHelper/Interfaces/IEatableHandler.cs
@@ -14,19 +14,39 @@
         /// <param name="water">The water value you want the item to have.</param>
         /// <param name="decomposes">Whether or not the item decomposes over time, losing food and water values in the process.</param>
         void ModifyEatable(TechType item, float food, float water, bool decomposes = true);
+        /// <summary>
+        /// Allows you to change the water/food values of a specific item.
+        /// </summary>
+        /// <param name="item">The TechType of the item you wish to edit.</param>
+        /// <param name="food">The food value you want the item to have.</param>
+        /// <param name="water">The water value you want the item to have.</param>
+        /// <param name="decomposes">Whether or not the item decomposes over time, losing food and water values in the process.</param>
+        void MakeEatable(TechType item, float food, float water, bool decomposes = true);
 #elif BELOWZERO
         /// <summary>
         /// Use this to change the values of a specific TechType.
         /// </summary>
-        /// <param name="item">the TechType of the item you want to change.</param>
-        /// <param name="food">the food value you want to change it to.</param>
-        /// <param name="water">the water value you want to change it to.</param>
-        /// <param name="decomposes">whether or not the item decomposes over time.</param>
-        /// <param name="health">how much you want to set the health gained from eating this item to.</param>
+        /// <param name="item">The TechType of the item you want to change.</param>
+        /// <param name="food">The food value you want to change it to.</param>
+        /// <param name="water">The water value you want to change it to.</param>
+        /// <param name="decomposes">Whether or not the item decomposes over time.</param>
+        /// <param name="health">How much you want to set the health gained from eating this item to.</param>
         /// <param name="coldValue">How much eating this item changes the current cold meter value.<br/>
         /// Negative values heats up the player while positive values makes the player colder.</param>
         /// <param name="maxCharges">How many times the item can be used before being consumed.</param>
         void ModifyEatable(TechType item, float food, float water, bool decomposes = true, float health = 0f, float coldValue = 0f, int maxCharges = 0);
+        /// <summary>
+        /// Use this to change the values of a specific TechType.
+        /// </summary>
+        /// <param name="item">The TechType of the item you want to change.</param>
+        /// <param name="food">The food value you want to change it to.</param>
+        /// <param name="water">The water value you want to change it to.</param>
+        /// <param name="decomposes">Whether or not the item decomposes over time.</param>
+        /// <param name="health">How much you want to set the health gained from eating this item to.</param>
+        /// <param name="coldValue">How much eating this item changes the current cold meter value.<br/>
+        /// Negative values heats up the player while positive values makes the player colder.</param>
+        /// <param name="maxCharges">How many times the item can be used before being consumed.</param>
+        void MakeEatable(TechType item, float food, float water, bool decomposes = true, float health = 0f, float coldValue = 0f, int maxCharges = 0);
 #endif
     }
 }

--- a/SMLHelper/Interfaces/IEatableHandler.cs
+++ b/SMLHelper/Interfaces/IEatableHandler.cs
@@ -15,9 +15,9 @@
         /// <param name="decomposes">Whether or not the item decomposes over time, losing food and water values in the process.</param>
         void ModifyEatable(TechType item, float food, float water, bool decomposes = true);
         /// <summary>
-        /// Allows you to change the water/food values of a specific item.
+        /// Allows you to make an item that isn't normally edible edible, with specific values
         /// </summary>
-        /// <param name="item">The TechType of the item you wish to edit.</param>
+        /// <param name="item">The TechType of the item you wish to make edible.</param>
         /// <param name="food">The food value you want the item to have.</param>
         /// <param name="water">The water value you want the item to have.</param>
         /// <param name="decomposes">Whether or not the item decomposes over time, losing food and water values in the process.</param>
@@ -36,9 +36,9 @@
         /// <param name="maxCharges">How many times the item can be used before being consumed.</param>
         void ModifyEatable(TechType item, float food, float water, bool decomposes = true, float health = 0f, float coldValue = 0f, int maxCharges = 0);
         /// <summary>
-        /// Use this to change the values of a specific TechType.
+        /// Allows you to make an item that isn't normally edible edible, with specific values
         /// </summary>
-        /// <param name="item">The TechType of the item you want to change.</param>
+        /// <param name="item">The TechType of the item you wish to make edible.</param>
         /// <param name="food">The food value you want to change it to.</param>
         /// <param name="water">The water value you want to change it to.</param>
         /// <param name="decomposes">Whether or not the item decomposes over time.</param>

--- a/SMLHelper/Patchers/PickupablePatcher.cs
+++ b/SMLHelper/Patchers/PickupablePatcher.cs
@@ -24,12 +24,8 @@ namespace SMLHelper.V2.Patchers
         {
             TechType tt = CraftData.GetTechType(__instance.gameObject);
 
-            EditedEatableValues value;
-            if(!AddedEatables.TryGetValue(tt, out value)) 
-                EatablePatcher.EditedEatables.TryGetValue(tt, out value);
-
-            if (value != null)
-            {
+            if (AddedEatables.TryGetValue(tt, out var value))
+                {
                 var eatable = __instance.gameObject.EnsureComponent<Eatable>();
                 eatable.foodValue = value.food;
                 eatable.waterValue = value.water;

--- a/SMLHelper/Patchers/PickupablePatcher.cs
+++ b/SMLHelper/Patchers/PickupablePatcher.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SMLHelper.V2.Patchers
+{
+    using HarmonyLib;
+    using System.Collections.Generic;
+    using static Handlers.EatableHandler;
+    internal class PickupablePatcher
+    {
+        internal static readonly IDictionary<TechType, EditedEatableValues> AddedEatables = new SelfCheckingDictionary<TechType, EditedEatableValues>("EditedEatableValues", TechTypeExtensions.sTechTypeComparer);
+
+        public static void Patch(Harmony harmony)
+        {
+            harmony.Patch(AccessTools.Method(typeof(Pickupable), nameof(Pickupable.Awake)),
+                new HarmonyMethod(typeof(PickupablePatcher), nameof(AwakePrefix)));
+
+            Logger.Debug("PickupablePatcher is done.");
+        }
+        private static void AwakePrefix(Pickupable __instance)
+        {
+            TechType tt = CraftData.GetTechType(__instance.gameObject);
+
+            EditedEatableValues value;
+            if(!AddedEatables.TryGetValue(tt, out value)) 
+                EatablePatcher.EditedEatables.TryGetValue(tt, out value);
+
+            if (value != null)
+            {
+                var eatable = __instance.gameObject.EnsureComponent<Eatable>();
+                eatable.foodValue = value.food;
+                eatable.waterValue = value.water;
+                eatable.decomposes = value.decomposes;
+#if BELOWZERO
+                eatable.healthValue = value.health;
+                eatable.maxCharges = value.maxCharges;
+                eatable.coldMeterValue = value.coldValue;
+#endif
+            }
+        }
+    }
+}


### PR DESCRIPTION
pickupable patch only gets patched if at least one edible is added, and it takes over the original eatable patch if so. No need to have two patches there when one would do, right?

mostly so that CC2 can allow for items to be made edible solely through smlhelper.