### PR TITLE
2.15.0.1 Hotfix for KnownTech.Analyze null ref exception with custom scannables 

### DIFF
--- a/Example mod/Mod.cs
+++ b/Example mod/Mod.cs
@@ -21,7 +21,7 @@
             MODNAME = "SMLHelper",
             AUTHOR = "The SMLHelper Dev Team",
             GUID = "SMLHelperExampleMod",
-            VERSION = "2.15.0.0";
+            VERSION = "2.15.0.1";
 
         internal static ManualLogSource LogSource { get; private set; }
 

--- a/SMLHelper/Handlers/KnownTechHandler.cs
+++ b/SMLHelper/Handlers/KnownTechHandler.cs
@@ -62,7 +62,10 @@ namespace SMLHelper.V2.Handlers
                         unlockMessage = UnlockMessage,
                         unlockSound = UnlockSound,
                         unlockPopup = UnlockSprite,
-                        unlockTechTypes = new List<TechType>(techTypesToUnlock)
+                        unlockTechTypes = new List<TechType>(techTypesToUnlock),
+                        //Secondary fix for null ref exception caused by Subnautica 2.0 moving story goal initialization
+                        //Maybe one day we expand this to actually be able to add list of StoryGoals from mods or base game???
+                        storyGoals = new()
                     });
                 }
             }

--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -20,7 +20,7 @@
         private const string
             MODNAME = "SMLHelper",
             GUID = "com.ahk1221.smlhelper",
-            VERSION = "2.15.0.0";
+            VERSION = "2.15.0.1";
 
         internal static readonly Harmony harmony = new Harmony(GUID);
 

--- a/SMLHelper/Patchers/KnownTechPatcher.cs
+++ b/SMLHelper/Patchers/KnownTechPatcher.cs
@@ -74,7 +74,8 @@
                 }
             }
 
-            foreach (KnownTech.AnalysisTech tech in techToAdd)
+            List<KnownTech.AnalysisTech> validatedTechsToAdd = KnownTech.ValidateAnalysisTech(new(techToAdd));
+            foreach (KnownTech.AnalysisTech tech in validatedTechsToAdd)
             {
                 if (tech == null)
                     continue;
@@ -86,18 +87,18 @@
                     analysisTech.Add(tech);
             }
 
-            List<KnownTech.CompoundTech> compoundTech = KnownTech.compoundTech;
-            foreach (KnownTech.CompoundTech customTech in CompoundTech.Values)
+            List <KnownTech.CompoundTech> validatedCompoundTeches = KnownTech.ValidateCompoundTech(new(CompoundTech.Values));
+            foreach (KnownTech.CompoundTech customTech in validatedCompoundTeches)
             {
                 if (customTech == null) // Safety check
                     continue;
 
                 // Only add the new compound tech if it isn't unlocked yet 
                 if (!KnownTech.Contains(customTech.techType))
-                    compoundTech.Add(customTech);
+                    KnownTech.compoundTech.Add(customTech);
 
                 // If a compound tech already exists, set the dependencies correctly.
-                var foundTech = compoundTech.Find(tech => tech.techType == customTech.techType);
+                var foundTech = KnownTech.compoundTech.Find(tech => tech.techType == customTech.techType);
                 if (foundTech != null)
                     foundTech.dependencies = customTech.dependencies;
             }

--- a/SMLHelper/ThunderstoreMetadata/BZ.EXP/manifest.json
+++ b/SMLHelper/ThunderstoreMetadata/BZ.EXP/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SMLHelper_BZ_Experimental",
-  "version_number": "2.15.0000",
+  "version_number": "2.15.0001",
   "website_url": "https://github.com/SubnauticaModding/SMLHelper/wiki",
   "description": "SMLHelper is a modding library that helps making mods easier by helping with adding new items, changing items, adding models, sprites, etc.",
   "dependencies": [ "Subnautica_Modding-BepInExPack-5.4.2101" ]

--- a/SMLHelper/ThunderstoreMetadata/BZ.STABLE/manifest.json
+++ b/SMLHelper/ThunderstoreMetadata/BZ.STABLE/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SMLHelper_BZ",
-  "version_number": "2.15.0000",
+  "version_number": "2.15.0001",
   "website_url": "https://github.com/SubnauticaModding/SMLHelper/wiki",
   "description": "SMLHelper is a modding library that helps making mods easier by helping with adding new items, changing items, adding models, sprites, etc.",
   "dependencies": [ "Subnautica_Modding-BepInExPack-5.4.2101" ]

--- a/SMLHelper/ThunderstoreMetadata/SN.EXP/manifest.json
+++ b/SMLHelper/ThunderstoreMetadata/SN.EXP/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SMLHelper_Experimental",
-  "version_number": "2.15.0000",
+  "version_number": "2.15.0001",
   "website_url": "https://github.com/SubnauticaModding/SMLHelper/wiki",
   "description": "SMLHelper is a modding library that helps making mods easier by helping with adding new items, changing items, adding models, sprites, etc.",
   "dependencies": [ "Subnautica_Modding-BepInExPack-5.4.2101" ]

--- a/SMLHelper/ThunderstoreMetadata/SN.STABLE/manifest.json
+++ b/SMLHelper/ThunderstoreMetadata/SN.STABLE/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SMLHelper",
-  "version_number": "2.15.0000",
+  "version_number": "2.15.0001",
   "website_url": "https://github.com/SubnauticaModding/SMLHelper/wiki",
   "description": "SMLHelper is a modding library that helps making mods easier by helping with adding new items, changing items, adding models, sprites, etc.",
   "dependencies": [ "Subnautica_Modding-BepInExPack-5.4.2101" ]

--- a/Version.targets
+++ b/Version.targets
@@ -2,6 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <!-- The assembly uses this version number. !-->
-        <Version>2.15.0</Version>
+        <Version>2.15.0.1</Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Validate modded analysisTechs and compoundTechs before adding to games lists
Initialize AnalysisTech.storyGoals list as it is no longer auto created and will cause a null ref exception after a modded tech with a scannable is unlocked


[SMLHelper_SN.STABLE.zip](https://github.com/SubnauticaModding/SMLHelper/files/10307105/SMLHelper_SN.STABLE.zip)

