### PR TITLE
Coordinated Spawns Callbacks

### DIFF
--- a/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
+++ b/SMLHelper/Handlers/CoordinatedSpawnsHandler.cs
@@ -137,6 +137,8 @@ namespace SMLHelper.V2.Handlers
         internal Quaternion Rotation { get; }
         [JsonProperty]
         internal SpawnType Type { get; }
+        [JsonIgnore] 
+        internal Action<GameObject> OnSpawned { get; }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -144,7 +146,16 @@ namespace SMLHelper.V2.Handlers
         /// <param name="techType">TechType to spawn.</param>
         /// <param name="spawnPosition">Position to spawn into.</param>
         public SpawnInfo(TechType techType, Vector3 spawnPosition)
-            : this(default, techType, spawnPosition, Quaternion.identity) { }
+            : this(default, techType, spawnPosition, Quaternion.identity, null) { }
+        
+        /// <summary>
+        /// Initializes a new <see cref="SpawnInfo"/>.
+        /// </summary>
+        /// <param name="techType">TechType to spawn.</param>
+        /// <param name="spawnPosition">Position to spawn into.</param>
+        /// <param name="onSpawned">Delegate to call when the object is successfully spawned.</param>
+        public SpawnInfo(TechType techType, Vector3 spawnPosition, Action<GameObject> onSpawned)
+            : this(default, techType, spawnPosition, Quaternion.identity, onSpawned) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -152,7 +163,16 @@ namespace SMLHelper.V2.Handlers
         /// <param name="classId">ClassID to spawn.</param>
         /// <param name="spawnPosition">Position to spawn into.</param>
         public SpawnInfo(string classId, Vector3 spawnPosition)
-            : this(classId, default, spawnPosition, Quaternion.identity) { }
+            : this(classId, default, spawnPosition, Quaternion.identity, null) { }
+        
+        /// <summary>
+        /// Initializes a new <see cref="SpawnInfo"/>.
+        /// </summary>
+        /// <param name="classId">ClassID to spawn.</param>
+        /// <param name="spawnPosition">Position to spawn into.</param>
+        /// <param name="onSpawned">Delegate to call when the object is successfully spawned.</param>
+        public SpawnInfo(string classId, Vector3 spawnPosition, Action<GameObject> onSpawned)
+            : this(classId, default, spawnPosition, Quaternion.identity, onSpawned) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -161,7 +181,17 @@ namespace SMLHelper.V2.Handlers
         /// <param name="spawnPosition">Position to spawn into.</param>
         /// <param name="rotation">Rotation to spawn at.</param>
         public SpawnInfo(TechType techType, Vector3 spawnPosition, Quaternion rotation)
-            : this(default, techType, spawnPosition, rotation) { }
+            : this(default, techType, spawnPosition, rotation, null) { }
+        
+        /// <summary>
+        /// Initializes a new <see cref="SpawnInfo"/>.
+        /// </summary>
+        /// <param name="techType">TechType to spawn.</param>
+        /// <param name="spawnPosition">Position to spawn into.</param>
+        /// <param name="rotation">Rotation to spawn at.</param>
+        /// <param name="onSpawned">Delegate to call when the object is successfully spawned.</param>
+        public SpawnInfo(TechType techType, Vector3 spawnPosition, Quaternion rotation, Action<GameObject> onSpawned)
+            : this(default, techType, spawnPosition, rotation, onSpawned) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -170,7 +200,17 @@ namespace SMLHelper.V2.Handlers
         /// <param name="spawnPosition">Position to spawn into.</param>
         /// <param name="rotation">Rotation to spawn at.</param>
         public SpawnInfo(string classId, Vector3 spawnPosition, Quaternion rotation)
-            : this(classId, default, spawnPosition, rotation) { }
+            : this(classId, default, spawnPosition, rotation, null) { }
+        
+        /// <summary>
+        /// Initializes a new <see cref="SpawnInfo"/>.
+        /// </summary>
+        /// <param name="classId">ClassID to spawn.</param>
+        /// <param name="spawnPosition">Position to spawn into.</param>
+        /// <param name="rotation">Rotation to spawn at.</param>
+        /// <param name="onSpawned">Delegate to call when the object is successfully spawned.</param>
+        public SpawnInfo(string classId, Vector3 spawnPosition, Quaternion rotation, Action<GameObject> onSpawned)
+            : this(classId, default, spawnPosition, rotation, onSpawned) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -179,7 +219,17 @@ namespace SMLHelper.V2.Handlers
         /// <param name="spawnPosition">Position to spawn into.</param>
         /// <param name="rotation">Rotation to spawn at.</param>
         public SpawnInfo(TechType techType, Vector3 spawnPosition, Vector3 rotation)
-            : this(default, techType, spawnPosition, Quaternion.Euler(rotation)) { }
+            : this(default, techType, spawnPosition, Quaternion.Euler(rotation), null) { }
+
+        /// <summary>
+        /// Initializes a new <see cref="SpawnInfo"/>.
+        /// </summary>
+        /// <param name="techType">TechType to spawn.</param>
+        /// <param name="spawnPosition">Position to spawn into.</param>
+        /// <param name="rotation">Rotation to spawn at.</param>
+        /// <param name="onSpawned">Delegate to call when the object is successfully spawned.</param>
+        public SpawnInfo(TechType techType, Vector3 spawnPosition, Vector3 rotation, Action<GameObject> onSpawned)
+            : this(default, techType, spawnPosition, Quaternion.Euler(rotation), onSpawned) { }
 
         /// <summary>
         /// Initializes a new <see cref="SpawnInfo"/>.
@@ -188,15 +238,16 @@ namespace SMLHelper.V2.Handlers
         /// <param name="spawnPosition">Position to spawn into.</param>
         /// <param name="rotation">Rotation to spawn at.</param>
         public SpawnInfo(string classId, Vector3 spawnPosition, Vector3 rotation)
-            : this(classId, default, spawnPosition, Quaternion.Euler(rotation)) { }
+            : this(classId, default, spawnPosition, Quaternion.Euler(rotation), null) { }
 
         [JsonConstructor]
-        internal SpawnInfo(string classId, TechType techType, Vector3 spawnPosition, Quaternion rotation)
+        internal SpawnInfo(string classId, TechType techType, Vector3 spawnPosition, Quaternion rotation, Action<GameObject> onSpawned)
         {
             ClassId = classId;
             TechType = techType;
             SpawnPosition = spawnPosition;
             Rotation = rotation;
+            OnSpawned = onSpawned;
             Type = TechType switch
             {
                 default(TechType) => SpawnType.ClassId,

--- a/SMLHelper/MonoBehaviours/EntitySpawner.cs
+++ b/SMLHelper/MonoBehaviours/EntitySpawner.cs
@@ -11,12 +11,12 @@ namespace SMLHelper.V2.MonoBehaviours
     {
         internal SpawnInfo spawnInfo;
 
-        void Start()
+        private void Start()
         {
             StartCoroutine(SpawnAsync());
         }
 
-        IEnumerator SpawnAsync()
+        private IEnumerator SpawnAsync()
         {
             var stringToLog = spawnInfo.Type switch
             {
@@ -57,13 +57,15 @@ namespace SMLHelper.V2.MonoBehaviours
             lw.streamer.cellManager.RegisterEntity(obj);
 
             obj.SetActive(true);
+            
+            spawnInfo.OnSpawned?.Invoke(obj);
 
             LargeWorldStreamerPatcher.savedSpawnInfos.Add(spawnInfo);
 
             Destroy(gameObject);
         }
 
-        IEnumerator GetPrefabAsync(IOut<GameObject> gameObject)
+        private IEnumerator GetPrefabAsync(IOut<GameObject> gameObject)
         {
             GameObject obj;
 

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -108,6 +108,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="7-Zip.CommandLine" Version="18.1.0" />
+    <PackageReference Include="PolySharp" Version="1.12.1" />
   </ItemGroup>
   <Import Project="$(SolutionDir)PostBuild.targets" />
 </Project>

--- a/SMLHelper/Utility/Polyfill.cs
+++ b/SMLHelper/Utility/Polyfill.cs
@@ -1,7 +1,0 @@
-﻿// fix for C# 9.0 (for pre-5.0 .NET) for records and 'init' property modifiers
-namespace System.Runtime.CompilerServices
-{
-    internal static class IsExternalInit
-    {
-    }
-}

--- a/SMLHelper/mod_BelowZero.json
+++ b/SMLHelper/mod_BelowZero.json
@@ -2,9 +2,9 @@
   "Id": "SMLHelper",
   "DisplayName": "SMLHelper",
   "Author": "The SMLHelper Dev Team",
-  "Version": "2.14.1",
+  "Version": "2.15.0",
   "Enable": true,
   "Game": "BelowZero",
   "AssemblyName": "SMLHelper.dll",
-  "VersionChecker": { "LatestVersionURL": "https://raw.githubusercontent.com/SubnauticaModding/SMLHelper/master/SMLHelper/mod_BelowZero.json" }
+  "VersionChecker": { "LatestVersionURL": "https://raw.githubusercontent.com/SubnauticaModding/SMLHelper/legacy/SMLHelper/mod_BelowZero.json" }
 }

--- a/SMLHelper/mod_Subnautica.json
+++ b/SMLHelper/mod_Subnautica.json
@@ -2,10 +2,10 @@
   "Id": "SMLHelper",
   "DisplayName": "SMLHelper",
   "Author": "The SMLHelper Dev Team",
-  "Version": "2.14.1",
+  "Version": "2.15.0",
   "Enable": true,
   "Game": "Subnautica",
   "AssemblyName": "SMLHelper.dll",
-  "VersionChecker": { "LatestVersionURL": "https://raw.githubusercontent.com/SubnauticaModding/SMLHelper/master/SMLHelper/mod_Subnautica.json" },
+  "VersionChecker": { "LatestVersionURL": "https://raw.githubusercontent.com/SubnauticaModding/SMLHelper/legacy/SMLHelper/mod_Subnautica.json" },
   "NitroxCompat": true
 }

--- a/Scripts/SMLHelper-post-build.ps1
+++ b/Scripts/SMLHelper-post-build.ps1
@@ -83,12 +83,18 @@ foreach ($file in "mod.json", "SMLHelper.xml", "SMLHelper.dll")
     Copy-Item $([System.IO.Path]::Combine($TargetDir, $file)) -Destination $buildDir
 }
 
+$zipPostfix = switch ($ConfigurationName.ToUpper())
+{
+    {($_ -like "SN*")} { "SN.LEGACY" }
+    {($_ -like "BZ*")} { "BZ.LEGACY" }
+}
+
 # Zip the standard QMod build
-$buildZipPath = [System.IO.Path]::Combine($TargetDir, "SMLHelper_$($ConfigurationName).zip")
+$buildZipPath = [System.IO.Path]::Combine($TargetDir, "SMLHelper_$($zipPostfix).zip")
 $null = Zip -Path $buildDir -DestinationPath $buildZipPath -Fresh
 
 # Zip the Thunderstore build
 $thunderstoreMetadataPath = [System.IO.Path]::Combine($ProjectDir, "ThunderstoreMetadata", $ConfigurationName, "*")
-$thunderstoreZipPath = [System.IO.Path]::Combine($TargetDir, "SMLHelper_$($ConfigurationName)_Thunderstore.zip")
+$thunderstoreZipPath = [System.IO.Path]::Combine($TargetDir, "SMLHelper_$($zipPostfix)_Thunderstore.zip")
 $null = Zip -Path $qmodsDir -DestinationPath $thunderstoreZipPath -Fresh
 $null = Zip -Path $thunderstoreMetadataPath -DestinationPath $thunderstoreZipPath

--- a/Version.targets
+++ b/Version.targets
@@ -2,6 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <!-- The assembly uses this version number. !-->
-        <Version>2.14.1</Version>
+        <Version>2.15.0</Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Changes made in this pull request

  - Added a few overloads to `SpawnInfo` for the on spawned event.
  
These callbacks will only be called once and the first time the object is spawned in the world. Purpose of this feature is to merely modify a few properties for vanilla objects whom are spawned using the `CoordinatedSpawns` system.

[SMLHelper_SN.LEGACY.zip](https://github.com/SubnauticaModding/SMLHelper/files/10550043/SMLHelper_SN.LEGACY.zip)