### PR TITLE
Change Options from List to IReadOnlyCollection

### DIFF
--- a/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
+++ b/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
@@ -100,7 +100,7 @@
         /// <summary>
         /// Adds options to the menu based on the <see cref="ConfigFileMetadata"/>.
         /// </summary>
-        public override void BuildModOptions(uGUI_TabbedControlsPanel panel, int modsTabIndex, IEnumerable<OptionItem> options)
+        public override void BuildModOptions(uGUI_TabbedControlsPanel panel, int modsTabIndex, List<OptionItem> options)
         {
 
             // Conditionally load the config
@@ -112,7 +112,7 @@
                     RemoveItem(option.Id);
                 }
             }
-            if(Options.Count() == 0)
+            if(Options.Count == 0)
             {
                 foreach(KeyValuePair<string, ModOptionAttributeMetadata<T>> entry in ConfigFileMetadata.ModOptionAttributesMetadata
                     .OrderBy(x => x.Value.ModOptionAttribute.Order)

--- a/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
+++ b/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
@@ -100,7 +100,7 @@
         /// <summary>
         /// Adds options to the menu based on the <see cref="ConfigFileMetadata"/>.
         /// </summary>
-        public override void BuildModOptions(uGUI_TabbedControlsPanel panel, int modsTabIndex, List<OptionItem> options)
+        public override void BuildModOptions(uGUI_TabbedControlsPanel panel, int modsTabIndex, IReadOnlyCollection<OptionItem> options)
         {
 
             // Conditionally load the config

--- a/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
+++ b/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs
@@ -100,7 +100,7 @@
         /// <summary>
         /// Adds options to the menu based on the <see cref="ConfigFileMetadata"/>.
         /// </summary>
-        public override void BuildModOptions(uGUI_TabbedControlsPanel panel, int modsTabIndex, List<OptionItem> options)
+        public override void BuildModOptions(uGUI_TabbedControlsPanel panel, int modsTabIndex, IEnumerable<OptionItem> options)
         {
 
             // Conditionally load the config
@@ -112,7 +112,7 @@
                     RemoveItem(option.Id);
                 }
             }
-            if(Options.Count == 0)
+            if(Options.Count() == 0)
             {
                 foreach(KeyValuePair<string, ModOptionAttributeMetadata<T>> entry in ConfigFileMetadata.ModOptionAttributesMetadata
                     .OrderBy(x => x.Value.ModOptionAttribute.Order)

--- a/SMLHelper/Options/ModOptions.cs
+++ b/SMLHelper/Options/ModOptions.cs
@@ -21,7 +21,7 @@
         /// <summary>
         /// Obtains the <see cref="OptionItem"/>s that belong to this instance. Can be null.
         /// </summary>
-        public List<OptionItem> Options => new List<OptionItem>(_options.Values);
+        public IReadOnlyCollection<OptionItem> Options => _options.Values;
 
         // This is a dictionary now in case we want to get the ModOption quickly
         // based on the provided ID.
@@ -78,7 +78,7 @@
         /// <summary>
         /// Builds up the configuration the options.
         /// </summary>
-        public virtual void BuildModOptions(uGUI_TabbedControlsPanel panel, int modsTabIndex, List<OptionItem> options)
+        public virtual void BuildModOptions(uGUI_TabbedControlsPanel panel, int modsTabIndex, IReadOnlyCollection<OptionItem> options)
         {
             panel.AddHeading(modsTabIndex, Name);
             options.ForEach(option => option.AddToPanel(panel, modsTabIndex));

--- a/SMLHelper/Options/ModOptions.cs
+++ b/SMLHelper/Options/ModOptions.cs
@@ -21,7 +21,7 @@
         /// <summary>
         /// Obtains the <see cref="OptionItem"/>s that belong to this instance. Can be null.
         /// </summary>
-        public List<OptionItem> Options => new List<OptionItem>(_options.Values);
+        public IEnumerable<OptionItem> Options => _options.Values;
 
         // This is a dictionary now in case we want to get the ModOption quickly
         // based on the provided ID.
@@ -78,7 +78,7 @@
         /// <summary>
         /// Builds up the configuration the options.
         /// </summary>
-        public virtual void BuildModOptions(uGUI_TabbedControlsPanel panel, int modsTabIndex, List<OptionItem> options)
+        public virtual void BuildModOptions(uGUI_TabbedControlsPanel panel, int modsTabIndex, IEnumerable<OptionItem> options)
         {
             panel.AddHeading(modsTabIndex, Name);
             options.ForEach(option => option.AddToPanel(panel, modsTabIndex));

--- a/SMLHelper/Options/ModOptions.cs
+++ b/SMLHelper/Options/ModOptions.cs
@@ -21,7 +21,7 @@
         /// <summary>
         /// Obtains the <see cref="OptionItem"/>s that belong to this instance. Can be null.
         /// </summary>
-        public IEnumerable<OptionItem> Options => _options.Values;
+        public List<OptionItem> Options => new List<OptionItem>(_options.Values);
 
         // This is a dictionary now in case we want to get the ModOption quickly
         // based on the provided ID.
@@ -78,7 +78,7 @@
         /// <summary>
         /// Builds up the configuration the options.
         /// </summary>
-        public virtual void BuildModOptions(uGUI_TabbedControlsPanel panel, int modsTabIndex, IEnumerable<OptionItem> options)
+        public virtual void BuildModOptions(uGUI_TabbedControlsPanel panel, int modsTabIndex, List<OptionItem> options)
         {
             panel.AddHeading(modsTabIndex, Name);
             options.ForEach(option => option.AddToPanel(panel, modsTabIndex));


### PR DESCRIPTION
Moving to an `IReadOnlyCollection` so that this value is more obvious that it is non-editable.

Not tested but builds and should be fairly straightforward as it's only really used in 2 places:

https://github.com/SubnauticaModding/SMLHelper/blob/8178e8b451a331a7c9b4d90f061c14d52682e082/SMLHelper/Options/Attributes/OptionsMenuBuilder.cs#L115

https://github.com/SubnauticaModding/SMLHelper/blob/8178e8b451a331a7c9b4d90f061c14d52682e082/SMLHelper/Options/ModOptions.cs#L81-L85