### PR TITLE
Material modifiers fix

### DIFF
--- a/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
+++ b/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
@@ -5,7 +5,7 @@ namespace SMLHelper.Utility.MaterialModifiers;
 /// <summary>
 /// Basic material modifier that sets the <see cref="Material.color"/> property on all materials.
 /// </summary>
-public class ColorModifier : MaterialModifier 
+public sealed class ColorModifier : MaterialModifier 
 {
     private Color color;
 
@@ -21,7 +21,7 @@ public class ColorModifier : MaterialModifier
     /// <summary>
     /// Applies the color changes to the material.
     /// </summary>
-    protected sealed override void ApplyChangesToMaterial(Material material, Renderer renderer, int materialIndex, MaterialUtils.MaterialType materialType)
+    protected override void ApplyChangesToMaterial(Material material, Renderer renderer, int materialIndex, MaterialUtils.MaterialType materialType)
     {
         material.color = color;
     }

--- a/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
+++ b/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
@@ -21,10 +21,7 @@ public class ColorModifier : MaterialModifier
     /// <summary>
     /// Applies the color changes to the material.
     /// </summary>
-    /// <param name="material"></param>
-    /// <param name="renderer"></param>
-    /// <param name="materialType"></param>
-    protected sealed override void ApplyChangesToMaterial(Material material, Renderer renderer, MaterialUtils.MaterialType materialType)
+    protected sealed override void ApplyChangesToMaterial(Material material, Renderer renderer, int materialIndex, MaterialUtils.MaterialType materialType)
     {
         material.color = color;
     }

--- a/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
+++ b/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
@@ -3,14 +3,14 @@
 namespace SMLHelper.Utility.MaterialModifiers;
 
 /// <summary>
-/// Applies a color
+/// Sets the <see cref="Material.color"/> property on all materials.
 /// </summary>
 public class ColorModifier : MaterialModifier 
 {
     private Color color;
 
     /// <summary>
-    /// Constructor.
+    /// Sets the <see cref="Material.color"/> property on all materials.
     /// </summary>
     /// <param name="color"></param>
     public ColorModifier(Color color)

--- a/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
+++ b/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
@@ -21,7 +21,7 @@ public sealed class ColorModifier : MaterialModifier
     /// <summary>
     /// Applies the color changes to the material.
     /// </summary>
-    protected override void ApplyChangesToMaterial(Material material, Renderer renderer, int materialIndex, MaterialUtils.MaterialType materialType)
+    public override void EditMaterial(Material material, Renderer renderer, int materialIndex, MaterialUtils.MaterialType materialType)
     {
         material.color = color;
     }

--- a/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
+++ b/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
@@ -1,0 +1,43 @@
+﻿using UnityEngine;
+
+namespace SMLHelper.Utility.MaterialModifiers;
+
+/// <summary>
+/// Applies a color
+/// </summary>
+public class ColorModifier : MaterialModifier 
+{
+    private Color color;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="color"></param>
+    public ColorModifier(Color color)
+    {
+        this.color = color;
+    }
+
+    /// <summary>
+    /// Applies changes to the material.
+    /// </summary>
+    /// <param name="material"></param>
+    /// <param name="renderer"></param>
+    /// <param name="materialType"></param>
+    protected sealed override void ApplyChangesToMaterial(Material material, Renderer renderer, MaterialUtils.MaterialType materialType)
+    {
+        material.color = color;
+    }
+
+    /// <summary>
+    /// Does not block shader conversions by default.
+    /// </summary>
+    /// <param name="material"></param>
+    /// <param name="renderer"></param>
+    /// <param name="materialType"></param>
+    /// <returns></returns>
+    public sealed override bool BlockShaderConversion(Material material, Renderer renderer, MaterialUtils.MaterialType materialType)
+    {
+        return false;
+    }
+}

--- a/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
+++ b/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
@@ -28,16 +28,4 @@ public class ColorModifier : MaterialModifier
     {
         material.color = color;
     }
-
-    /// <summary>
-    /// Does not block shader conversions by default.
-    /// </summary>
-    /// <param name="material"></param>
-    /// <param name="renderer"></param>
-    /// <param name="materialType"></param>
-    /// <returns></returns>
-    public sealed override bool BlockShaderConversion(Material material, Renderer renderer, MaterialUtils.MaterialType materialType)
-    {
-        return false;
-    }
 }

--- a/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
+++ b/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
@@ -3,7 +3,7 @@
 namespace SMLHelper.Utility.MaterialModifiers;
 
 /// <summary>
-/// Sets the <see cref="Material.color"/> property on all materials.
+/// Basic material modifier that sets the <see cref="Material.color"/> property on all materials.
 /// </summary>
 public class ColorModifier : MaterialModifier 
 {

--- a/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
+++ b/SMLHelper/Utility/MaterialModifiers/ColorModifier.cs
@@ -19,7 +19,7 @@ public class ColorModifier : MaterialModifier
     }
 
     /// <summary>
-    /// Applies changes to the material.
+    /// Applies the color changes to the material.
     /// </summary>
     /// <param name="material"></param>
     /// <param name="renderer"></param>

--- a/SMLHelper/Utility/MaterialModifiers/MaterialModifier.cs
+++ b/SMLHelper/Utility/MaterialModifiers/MaterialModifier.cs
@@ -10,18 +10,20 @@ public abstract class MaterialModifier
     /// <summary>
     /// Method called after all other material conversions have finished.
     /// </summary>
-    /// <param name="material">The material being modified.</param>
-    /// <param name="renderer">The renderer using the <paramref name="material"/>.</param>
-    /// <param name="materialType">The type of material that this can be expected to be. Determined in <see cref="MaterialUtils.ApplySNShaders"/> based on specific keywords.</param>
-    public void EditMaterial(Material material, Renderer renderer, MaterialUtils.MaterialType materialType)
+    public void EditMaterial(Material material, Renderer renderer, int materialIndex, MaterialUtils.MaterialType materialType)
     {
-        ApplyChangesToMaterial(material, renderer, materialType);
+        ApplyChangesToMaterial(material, renderer, materialIndex, materialType);
     }
 
     /// <summary>
     /// Method called after all other material conversions have finished. Override to implement your own custom behaviour, such as property changes or shader conversions.
     /// </summary>
-    protected virtual void ApplyChangesToMaterial(Material material, Renderer renderer, MaterialUtils.MaterialType materialType)
+    /// <param name="material">The material being modified.</param>
+    /// <param name="renderer">The renderer using the <paramref name="material"/>.</param>
+    /// <param name="materialIndex">The index of the given <paramref name="material"/> in its <see cref="Renderer"/>.</param>
+    /// <param name="materialType">The type of material that this can be expected to be. Determined in <see cref="MaterialUtils.ApplySNShaders"/> based on specific keywords.</param>
+
+    protected virtual void ApplyChangesToMaterial(Material material, Renderer renderer, int materialIndex, MaterialUtils.MaterialType materialType)
     {
 
     }

--- a/SMLHelper/Utility/MaterialModifiers/MaterialModifier.cs
+++ b/SMLHelper/Utility/MaterialModifiers/MaterialModifier.cs
@@ -3,12 +3,12 @@
 using UnityEngine;
 
 /// <summary>
-/// Basic Material Modifier that only affects Particle Systems. By default ignores these materials completely. Can be overriden to implement custom behaviour.
+/// Base class for material modifiers. Can be overriden to implement custom behaviour.
 /// </summary>
-public class MaterialModifier
+public abstract class MaterialModifier
 {
     /// <summary>
-    /// Basic Material Modifier that only affects Particle Systems. By default ignores these materials completely. Can be overriden to implement custom behaviour.
+    /// Base class for material modifiers. Can be overriden to implement custom behaviour.
     /// </summary>
     public MaterialModifier()
     {

--- a/SMLHelper/Utility/MaterialModifiers/MaterialModifier.cs
+++ b/SMLHelper/Utility/MaterialModifiers/MaterialModifier.cs
@@ -8,13 +8,6 @@ using UnityEngine;
 public abstract class MaterialModifier
 {
     /// <summary>
-    /// Base class for material modifiers. Can be overriden to implement custom behaviour.
-    /// </summary>
-    public MaterialModifier()
-    {
-    }
-
-    /// <summary>
     /// Method called after all other material conversions have finished.
     /// </summary>
     /// <param name="material">The material being modified.</param>
@@ -26,7 +19,7 @@ public abstract class MaterialModifier
     }
 
     /// <summary>
-    /// Only called for Materials on ParticleRenderers. Override to implement your own custom behaviour, such as shader conversions.
+    /// Method called after all other material conversions have finished. Override to implement your own custom behaviour, such as property changes or shader conversions.
     /// </summary>
     protected virtual void ApplyChangesToMaterial(Material material, Renderer renderer, MaterialUtils.MaterialType materialType)
     {

--- a/SMLHelper/Utility/MaterialModifiers/MaterialModifier.cs
+++ b/SMLHelper/Utility/MaterialModifiers/MaterialModifier.cs
@@ -10,23 +10,12 @@ public abstract class MaterialModifier
     /// <summary>
     /// Method called after all other material conversions have finished.
     /// </summary>
-    public void EditMaterial(Material material, Renderer renderer, int materialIndex, MaterialUtils.MaterialType materialType)
-    {
-        ApplyChangesToMaterial(material, renderer, materialIndex, materialType);
-    }
-
-    /// <summary>
-    /// Method called after all other material conversions have finished. Override to implement your own custom behaviour, such as property changes or shader conversions.
-    /// </summary>
     /// <param name="material">The material being modified.</param>
     /// <param name="renderer">The renderer using the <paramref name="material"/>.</param>
     /// <param name="materialIndex">The index of the given <paramref name="material"/> in its <see cref="Renderer"/>.</param>
     /// <param name="materialType">The type of material that this can be expected to be. Determined in <see cref="MaterialUtils.ApplySNShaders"/> based on specific keywords.</param>
 
-    protected virtual void ApplyChangesToMaterial(Material material, Renderer renderer, int materialIndex, MaterialUtils.MaterialType materialType)
-    {
-
-    }
+    public abstract void EditMaterial(Material material, Renderer renderer, int materialIndex, MaterialUtils.MaterialType materialType);
 
     /// <summary>
     /// Method called before any shader conversions and material modifiers are applied. By default returns false.<br/>

--- a/SMLHelper/Utility/MaterialModifiers/MaterialModifier.cs
+++ b/SMLHelper/Utility/MaterialModifiers/MaterialModifier.cs
@@ -22,10 +22,7 @@ public class MaterialModifier
     /// <param name="materialType">The type of material that this can be expected to be. Determined in <see cref="MaterialUtils.ApplySNShaders"/> based on specific keywords.</param>
     public void EditMaterial(Material material, Renderer renderer, MaterialUtils.MaterialType materialType)
     {
-        if (renderer is ParticleSystemRenderer)
-        {
-            ApplyChangesToMaterial(material, renderer, materialType);
-        }
+        ApplyChangesToMaterial(material, renderer, materialType);
     }
 
     /// <summary>
@@ -37,15 +34,15 @@ public class MaterialModifier
     }
 
     /// <summary>
-    /// Method called before any shader conversions and material modifiers are applied.<br/>
-    /// If <see langword="true"/> is returned from any MaterialModifier, the shader of <paramref name="material"/> will <i>not</i> be converted to MarmosetUBER. However, all modifiers will still be applied normally.
+    /// Method called before any shader conversions and material modifiers are applied. By default returns false.<br/>
+    /// If <see langword="true"/> is returned from ANY MaterialModifier, the shader of <paramref name="material"/> will <i>not</i> be converted to MarmosetUBER. However, all modifiers will still be applied normally.
     /// </summary>
     /// <param name="material">The material being evalauted.</param>
     /// <param name="renderer">The renderer using the <paramref name="material"/>.</param>
     /// <param name="materialType">The type of material that this can be expected to be. Determined in <see cref="MaterialUtils.ApplySNShaders"/> based on specific keywords.</param>
     /// <returns></returns>
-    public bool BlockShaderConversion(Material material, Renderer renderer, MaterialUtils.MaterialType materialType)
+    public virtual bool BlockShaderConversion(Material material, Renderer renderer, MaterialUtils.MaterialType materialType)
     {
-        return renderer is ParticleSystemRenderer;
+        return false;
     }
 }

--- a/SMLHelper/Utility/MaterialUtils.cs
+++ b/SMLHelper/Utility/MaterialUtils.cs
@@ -78,7 +78,7 @@ public static partial class MaterialUtils
                 {
                     foreach (var modifier in modifiers)
                     {
-                        modifier.EditMaterial(material, renderers[i], materialType);
+                        modifier.EditMaterial(material, renderers[i], j, materialType);
                     }
                 }
             }

--- a/SMLHelper/Utility/MaterialUtils.cs
+++ b/SMLHelper/Utility/MaterialUtils.cs
@@ -34,7 +34,7 @@ public static partial class MaterialUtils
     /// <param name="shininess">'_Shininess' value of the shader. Recommended range of 1.0f-8.0f.</param>
     /// <param name="specularIntensity">'_SpecularInt' value of the shader. Values around 1f are recommended.</param>
     /// <param name="glowStrength">'_GlowStrength' and '_GlowStrengthNight' value of the shader. Should not be absurdly high.</param>
-    /// <param name="modifiers">Optional array of classes that inherit from the <see cref="MaterialModifier"/> class. This allows for extensive customization of the method. Called in ascending order.</param>
+    /// <param name="modifiers">Optional array of classes that inherit from the <see cref="MaterialModifier"/> class. This allows for extensive customization of the method. Called in ascending order on every material.</param>
     public static void ApplySNShaders(GameObject gameObject, float shininess = 4f, float specularIntensity = 1f, float glowStrength = 1f, params MaterialModifier[] modifiers)
     {
         var renderers = gameObject.GetComponentsInChildren<Renderer>(true);


### PR DESCRIPTION
### Changes made in this pull request

  - Improved design of MaterialModifiers to be viable for general usage.
    - Fixed a bug that stopped them from running on most materials.
    - Made BlockShaderConversion virtual (it should have been from the start).
  - Updated documentation of MaterialUtils and related classes.
  - Added basic ColorModifier material modifier for example purposes & basic use cases.
  - Pass in `materialIndex` to allow swapping of materials through renderers by index.