### PR TITLE
Localization

### DIFF
--- a/Example mod/CustomFabricatorExample.cs
+++ b/Example mod/CustomFabricatorExample.cs
@@ -94,16 +94,23 @@ public class CustomFabricatorExample : BaseUnityPlugin
 	        }
         };
 
+#if JSONRECIPE
         /*
          * Set the recipe to the json object we made earlier.
          */
         customFab.SetRecipeFromJson(recipeJson);
-        
-        /*
-         * Make the modification station a requirement for our custom fabricator blueprint.
-         * Additionally we also add our custom fabricator to the Interior modules PDA group and category.
-         * Setting the tech group to a group that exists in the habitat builder will make our item buildable.
-         */
+#else
+	    /*
+	     * Set the recipe.
+	     */
+	    customFab.SetRecipe(recipe);
+#endif
+
+	    /*
+	     * Make the modification station a requirement for our custom fabricator blueprint.
+	     * Additionally we also add our custom fabricator to the Interior modules PDA group and category.
+	     * Setting the tech group to a group that exists in the habitat builder will make our item buildable.
+	     */
         customFab.SetUnlock(TechType.Workbench)
             .WithPdaGroupCategory(TechGroup.InteriorModules, TechCategory.InteriorModule);
         

--- a/Example mod/CustomPrefabExamples.cs
+++ b/Example mod/CustomPrefabExamples.cs
@@ -23,48 +23,48 @@ public class CustomPrefabExamples : BaseUnityPlugin
          * Every custom prefab will require an instance of PrefabInfo, which ultimately has all the info required to
          * make this item work in the game.
          */
-        PrefabInfo titaniumCloneInfo = PrefabInfo.WithTechType("TitaniumClone", "Titanium Clone", "Titanium clone that makes me go yes.");
+        PrefabInfo copperCloneInfo = PrefabInfo.WithTechType("CopperClone", "Copper Ore Clone", "Copper Ore clone that makes me go yes.");
         
         /*
-         * Here we're assigning the Titanium icon for our item.
+         * Here we're assigning the Copper icon for our item.
          * You may also use a custom image as your icon by calling the ImageUtils.LoadSpriteFromFile method.
          */
-        titaniumCloneInfo.WithIcon(SpriteManager.Get(TechType.Titanium));
+        copperCloneInfo.WithIcon(SpriteManager.Get(TechType.Copper));
         
         /*
          * Here we are setting up an instance of CustomPrefab.
          * CustomPrefab is where you actually add logic and birth to your item.
          * Here you will be able to add a game object for your item, set spawns, recipe, etc.. for your item.
          */
-        CustomPrefab titaniumClone = new CustomPrefab(titaniumCloneInfo);
+        CustomPrefab copperClone = new CustomPrefab(copperCloneInfo);
 
         /*
-         * Here we are creating a clone of the Titanium game object.
+         * Here we are creating a clone of the Copper game object.
          * Additionally, we are also changing the color of the clone to red.
          */
-        PrefabTemplate cloneTemplate = new CloneTemplate(titaniumCloneInfo, TechType.Titanium)
+        PrefabTemplate cloneTemplate = new CloneTemplate(copperCloneInfo, TechType.Copper)
         {
             // Callback to change all material colors of this clone to red.
             ModifyPrefab = prefab => prefab.GetComponentsInChildren<Renderer>().ForEach(r => r.materials.ForEach(m => m.color = Color.red))
         };
         
         /*
-         * Here we are setting the Titanium clone we created earlier as our item's prefab.
+         * Here we are setting the Copper clone we created earlier as our item's prefab.
          */
-        titaniumClone.SetGameObject(cloneTemplate);
+        copperClone.SetGameObject(cloneTemplate);
 
         /*
          * Then we added biome spawns for our item.
          */
-        titaniumClone.SetSpawns(new BiomeData { biome = BiomeType.SafeShallows_Grass, count = 4, probability = 0.1f },
+        copperClone.SetSpawns(new BiomeData { biome = BiomeType.SafeShallows_Grass, count = 4, probability = 0.1f },
             new BiomeData { biome = BiomeType.SafeShallows_CaveFloor, count = 1, probability = 0.4f });
         
         /*
          * And finally, we register it to the game.
-         * Now we can spawn our item to the world manually by using the command 'spawn titaniumclone', or
+         * Now we can spawn our item to the world manually by using the command 'spawn copperclone', or
          * simply looking around in the Safe shallows.
          * Refrain from modifying the item further more or adding more gadgets after Register is called as they will not be called.
          */
-        titaniumClone.Register();
+        copperClone.Register();
     }
 }

--- a/Example mod/Example mod.csproj
+++ b/Example mod/Example mod.csproj
@@ -69,4 +69,13 @@
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.1.0" />
     <PackageReference Include="PolySharp" Version="1.12.1" />
   </ItemGroup>
+  <Target Name="CopyToOutputPath" AfterTargets="Build">
+    <ItemGroup>
+      <LocalizationFiles Include="Localization\*.*" />
+    </ItemGroup>
+    <Copy
+            SourceFiles="@(LocalizationFiles)"
+            DestinationFolder="$(OutDir)\Localization"
+            SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/Example mod/Localization/English.json
+++ b/Example mod/Localization/English.json
@@ -1,0 +1,4 @@
+﻿{
+  "TitaniumClone": "Titanium Clone",
+  "Tooltip_TitaniumClone": "Titanium clone that makes me go yes."
+}

--- a/Example mod/Localization/Spanish.json
+++ b/Example mod/Localization/Spanish.json
@@ -1,0 +1,4 @@
+﻿{
+  "TitaniumClone": "Clon de Titanio",
+  "Tooltip_TitaniumClone": "Clon de Titanio que me hace decir que sí"
+}

--- a/Example mod/LocalizationExample.cs
+++ b/Example mod/LocalizationExample.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using BepInEx;
+using SMLHelper.Assets;
+using SMLHelper.Assets.PrefabTemplates;
+using SMLHelper.Handlers;
+
+namespace SMLHelper.Examples;
+
+[BepInPlugin("com.snmodding.smlhelper.localizaion", "SMLHelper Localization Example Mod", PluginInfo.PLUGIN_VERSION)]
+[BepInDependency("com.snmodding.smlhelper")]
+public class LocalizationExample : BaseUnityPlugin
+{
+    /*
+     * Here we have a dictionary that contains language keys and values for certain stuff.
+     * The language key for the display name of TechTypes is "{enumName}".
+     * Since our Titanium Clone's tech type is "TitaniumClone", this is what we will use for the display name.
+     *
+     * Similarly, for tooltips, the language key is "Tooltip_{enumName}", so for our Titanium Clone, it would be "Tooltip_TitaniumClone".
+     */
+    private Dictionary<string, string> _languageEntriesEng = new()
+    {
+        { "TitaniumClone", "Titanium Clone" }, { "Tooltip_TitaniumClone", "Titanium clone that makes me go yes." }
+    };
+    
+    /*
+     * Here we have a dictionary that translates the language entries above to Spanish.
+     * Keep in mind that the language keys are the same for every language.
+     */
+    private Dictionary<string, string> _languageEntriesEsp = new()
+    {
+        { "TitaniumClone", "Clon de Titanio" }, { "Tooltip_TitaniumClone", "Clon de Titanio que me hace decir que sí" }
+    };
+
+    private void Awake()
+    {
+        // Register our English language entries to the English language
+        LanguageHandler.RegisterLocalization("English", _languageEntriesEng);
+        
+        // Register our Spanish language entries to the Spanish language
+        LanguageHandler.RegisterLocalization("Spanish", _languageEntriesEsp);
+        
+        /*
+         * Create a CustomPrefab instance for our Titanium Clone. Must be set to null or empty if you registered language entries
+         * for them earlier like we did.
+         */ 
+        var titaniumClone = new CustomPrefab("TitaniumClone", null, null, SpriteManager.Get(TechType.Titanium));
+        
+        // Set our prefab's game object to a clone of the Titanium prefab
+        titaniumClone.SetGameObject(new CloneTemplate(titaniumClone.Info, TechType.Titanium));
+        
+        /*
+         * Register our Titanium Clone to the game.
+         * After this point, do not edit the prefab or modify gadgets as they will not be applied.
+         */
+        titaniumClone.Register();
+    }
+}

--- a/Example mod/LocalizationExample.cs
+++ b/Example mod/LocalizationExample.cs
@@ -33,12 +33,22 @@ public class LocalizationExample : BaseUnityPlugin
 
     private void Awake()
     {
+#if LOCALIZATION_FOLDER
+        /*
+         * Registers a folder as localization folder.
+         * This folder must contain json files that are named after the language they translate.
+         * For example, English translation must be named English.json and Spanish translation must be named Spanish.json.
+         * SML expects this folder to be located in the mod folder at ModName/Localization by default.
+         */
+        LanguageHandler.RegisterLocalizationFolder();
+#else
         // Register our English language entries to the English language
         LanguageHandler.RegisterLocalization("English", _languageEntriesEng);
         
         // Register our Spanish language entries to the Spanish language
         LanguageHandler.RegisterLocalization("Spanish", _languageEntriesEsp);
-        
+#endif
+
         /*
          * Create a CustomPrefab instance for our Titanium Clone. Must be set to null or empty if you registered language entries
          * for them earlier like we did.

--- a/SMLHelper/Assets/Gadgets/CraftingGadget.cs
+++ b/SMLHelper/Assets/Gadgets/CraftingGadget.cs
@@ -36,8 +36,8 @@ public class CraftingGadget : Gadget
     /// <summary>
     /// Constructs a crafting gadget.
     /// </summary>
-    /// <param name="prefab"><inheritdoc cref="Gadget(ICustomPrefab)"/></param>
-    /// <param name="techData">The crafting recipe to add.</param>
+    /// <param name="prefab">The custom prefab to operate on.</param>
+    /// <param name="recipeData">The crafting recipe to add.</param>
     [SetsRequiredMembers]
     public CraftingGadget(ICustomPrefab prefab, RecipeData recipeData) : base(prefab)
     {

--- a/SMLHelper/Assets/Gadgets/EquipmentGadget.cs
+++ b/SMLHelper/Assets/Gadgets/EquipmentGadget.cs
@@ -29,7 +29,7 @@ public class EquipmentGadget : Gadget
     /// <summary>
     /// Constructs an equipment gadget.
     /// </summary>
-    /// <param name="prefab"><inheritdoc cref="Gadget(ICustomPrefab)"/></param>
+    /// <param name="prefab">The custom prefab to operate on.</param>
     /// <param name="equipmentType">The type of equipment slot this item can fit into.</param>
     [SetsRequiredMembers]
     public EquipmentGadget(ICustomPrefab prefab, EquipmentType equipmentType) : base(prefab)

--- a/SMLHelper/Assets/Gadgets/FabricatorGadget.cs
+++ b/SMLHelper/Assets/Gadgets/FabricatorGadget.cs
@@ -45,16 +45,17 @@ public class FabricatorGadget : Gadget
     /// Adds a new tab node to the custom crafting tree of this fabricator.
     /// </summary>
     /// <param name="tabId">The internal ID for the tab node.</param>
-    /// <param name="displayText">The in-game text shown for the tab node.</param>
+    /// <param name="displayText">The in-game text shown for the tab node. If null or empty, this will use the language line "{CraftTreeTypeName}_{<paramref name="tabId"/>}" instead.</param>
     /// <param name="tabIcon">The sprite used for the tab node.</param>
+    /// <param name="language">The language for the display name. Defaults to English.</param>
     /// <param name="parentTabId">Optional. The parent tab of this tab.
     /// When this value is null, the tab will be added to the root of the craft tree.</param>
-    public FabricatorGadget AddTabNode(string tabId, string displayText, Sprite tabIcon, string parentTabId = null)
+    public FabricatorGadget AddTabNode(string tabId, string displayText, Sprite tabIcon, string language = "English", string parentTabId = null)
     {
         _orderedCraftTreeActions.Add(() =>
         {
             var parentNode = _craftTreeLinkingNodes[parentTabId ?? RootNode];
-            var tab = parentNode.AddTabNode(tabId, displayText, tabIcon);
+            var tab = parentNode.AddTabNode(tabId, displayText, tabIcon, language);
             _craftTreeLinkingNodes[tabId] = tab;
         });
 

--- a/SMLHelper/Assets/Gadgets/GadgetExtensions.cs
+++ b/SMLHelper/Assets/Gadgets/GadgetExtensions.cs
@@ -1,7 +1,5 @@
 using System.IO;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Serialization;
 using SMLHelper.Crafting;
 using SMLHelper.Handlers;
 using SMLHelper.Json.Converters;
@@ -24,7 +22,7 @@ public static class GadgetExtensions
     /// <returns>An instance to the created <see cref="CraftingGadget"/> to continue the recipe settings on.</returns>
     public static CraftingGadget SetRecipe(this ICustomPrefab customPrefab, RecipeData recipeData)
     {
-        if (customPrefab.TryGetGadget(out CraftingGadget craftingGadget))
+        if (!customPrefab.TryGetGadget(out CraftingGadget craftingGadget))
         { 
             craftingGadget = new CraftingGadget(customPrefab, recipeData);
         }
@@ -61,7 +59,7 @@ public static class GadgetExtensions
             return null;
         }
 
-        if (customPrefab.TryGetGadget(out CraftingGadget craftingGadget))
+        if (!customPrefab.TryGetGadget(out CraftingGadget craftingGadget))
         { 
             craftingGadget = new CraftingGadget(customPrefab, recipeData);
         }

--- a/SMLHelper/Assets/PrefabInfo.cs
+++ b/SMLHelper/Assets/PrefabInfo.cs
@@ -19,12 +19,13 @@ public record struct PrefabInfo(string ClassID, string PrefabFileName, TechType 
     /// Constructs a new <see cref="PrefabInfo"/> instance with automatically set <see cref="PrefabFileName"/> and <see cref="TechType"/>.
     /// </summary>
     /// <param name="classId">The class identifier used for the <see cref="PrefabIdentifier"/> component whenever applicable.</param>
-    /// <param name="displayName">The display name for this tech type.</param>
-    /// <param name="description">The description for this tech type.</param>
+    /// <param name="displayName">The display name of this Tech Type, can be anything. If null or empty, this will use the language line "{enumName}" instead.</param>
+    /// <param name="description">The tooltip displayed when hovered in the PDA, can be anything. If null or empty, this will use the language line "Tooltip_{enumName}" instead.</param>
+    /// <param name="language">The language for this entry. Defaults to English.</param>
     /// <param name="unlockAtStart">Whether this tech type should be unlocked on game start or not. Default to <see langword="true"/>.</param>
     /// <param name="techTypeOwner">The assembly that owns the created tech type. The name of this assembly will be shown in the PDA.</param>
     /// <returns>An instance of the constructed <see cref="PrefabInfo"/>.</returns>
-    public static PrefabInfo WithTechType(string classId, string displayName, string description, bool unlockAtStart = true, Assembly techTypeOwner = null)
+    public static PrefabInfo WithTechType(string classId, string displayName, string description, string language = "English", bool unlockAtStart = true, Assembly techTypeOwner = null)
     {
         techTypeOwner ??= Assembly.GetCallingAssembly();
         techTypeOwner = techTypeOwner == Assembly.GetExecutingAssembly()
@@ -34,7 +35,7 @@ public record struct PrefabInfo(string ClassID, string PrefabFileName, TechType 
         (
             classId, 
             classId + "Prefab",
-            EnumHandler.AddEntry<TechType>(classId, techTypeOwner).WithPdaInfo(displayName, description, unlockAtStart)
+            EnumHandler.AddEntry<TechType>(classId, techTypeOwner).WithPdaInfo(displayName, description, language, unlockAtStart)
         );
     }
 

--- a/SMLHelper/Crafting/ModCraftTreeLinkingNode.cs
+++ b/SMLHelper/Crafting/ModCraftTreeLinkingNode.cs
@@ -27,14 +27,13 @@ namespace SMLHelper.Crafting
         /// Creates a new tab node for the crafting tree and links it to the calling node.
         /// </summary>
         /// <param name="nameID">The name/ID of this node.</param>
-        /// <param name="displayText">The hover text to display in-game.</param>
+        /// <param name="displayText">The hover text to display in-game. If null or empty, this will use the language line "{CraftTreeName}_{<paramref name="nameID"/>}" instead.</param>
         /// <param name="sprite">The custom sprite to display on this tab node.</param>
+        /// <param name="language">The language for the display name. Defaults to English.</param>
         /// <returns>A new tab node linked to the root node and ready to use.</returns>
-        public ModCraftTreeTab AddTabNode(string nameID, string displayText, Atlas.Sprite sprite)
+        public ModCraftTreeTab AddTabNode(string nameID, string displayText, Atlas.Sprite sprite, string language = "English")
         {
-            string modName = ReflectionHelper.CallingAssemblyNameByStackTrace();
-
-            var tabNode = new ModCraftTreeTab(modName, nameID, displayText, sprite);
+            var tabNode = new ModCraftTreeTab(nameID, displayText, language, sprite);
             tabNode.LinkToParent(this);
 
             ChildNodes.Add(tabNode);
@@ -47,14 +46,13 @@ namespace SMLHelper.Crafting
         /// Creates a new tab node for the crafting tree and links it to the calling node.
         /// </summary>
         /// <param name="nameID">The name/ID of this node.</param>
-        /// <param name="displayText">The hover text to display in-game.</param>
+        /// <param name="displayText">The hover text to display in-game. If null or empty, this will use the language line "{CraftTreeName}_{<paramref name="nameID"/>}" instead.</param>
         /// <param name="sprite">The custom sprite to display on this tab node.</param>
+        /// <param name="language">The language for the display name. Defaults to English.</param>
         /// <returns>A new tab node linked to the root node and ready to use.</returns>
-        public ModCraftTreeTab AddTabNode(string nameID, string displayText, Sprite sprite)
+        public ModCraftTreeTab AddTabNode(string nameID, string displayText, Sprite sprite, string language = "English")
         {
-            string modName = ReflectionHelper.CallingAssemblyNameByStackTrace();
-
-            ModCraftTreeTab tabNode = new(modName, nameID, displayText, sprite);
+            ModCraftTreeTab tabNode = new(nameID, displayText, language, sprite);
             tabNode.LinkToParent(this);
 
             ChildNodes.Add(tabNode);
@@ -69,9 +67,7 @@ namespace SMLHelper.Crafting
         /// <returns>A new tab node linked to the root node and ready to use.</returns>
         public ModCraftTreeTab AddTabNode(string nameID)
         {
-            string modName = ReflectionHelper.CallingAssemblyNameByStackTrace();
-
-            ModCraftTreeTab tabNode = new(modName, nameID);
+            ModCraftTreeTab tabNode = new(nameID);
             tabNode.LinkToParent(this);
 
             ChildNodes.Add(tabNode);

--- a/SMLHelper/Crafting/ModCraftTreeRoot.cs
+++ b/SMLHelper/Crafting/ModCraftTreeRoot.cs
@@ -78,11 +78,12 @@
         /// Adds a new tab node to the custom crafting tree of this fabricator.
         /// </summary>
         /// <param name="tabId">The internal ID for the tab node.</param>
-        /// <param name="displayText">The in-game text shown for the tab node.</param>
+        /// <param name="displayText">The in-game text shown for the tab node. If null or empty, this will use the language line "{CraftTreeName}_{<paramref name="tabId"/>}" instead.</param>
         /// <param name="tabSprite">The sprite used for the tab node.</param>
+        /// <param name="language">The language for the display name. Defaults to English.</param>
         /// <param name="parentTabId">Optional. The parent tab of this tab.<para/>
         /// When this value is null, the tab will be added to the root of the craft tree.</param>
-        public ModCraftTreeRoot AddTabNode(string tabId, string displayText, Atlas.Sprite tabSprite, string parentTabId = null)
+        public ModCraftTreeRoot AddTabNode(string tabId, string displayText, Atlas.Sprite tabSprite, string language = "English", string parentTabId = null)
         {
             if(string.IsNullOrWhiteSpace(tabId))
                 throw new ArgumentNullException($"{this.SchemeAsString} tried to add a tab without an id! tabid cannot be null or empty spaces!");
@@ -93,7 +94,7 @@
 
             if(!parentTab.ChildNodes.Any(node => node.Action == TreeAction.Craft))
             {
-                ModCraftTreeTab tab = parentTab.AddTabNode(tabId, displayText, tabSprite);
+                ModCraftTreeTab tab = parentTab.AddTabNode(tabId, displayText, tabSprite, language);
                 CraftTreeLinkingNodes[tabId] = tab;
             }
             else
@@ -108,11 +109,12 @@
         /// Adds a new tab node to the custom crafting tree of this fabricator.
         /// </summary>
         /// <param name="tabId">The internal ID for the tab node.</param>
-        /// <param name="displayText">The in-game text shown for the tab node.</param>
+        /// <param name="displayText">The in-game text shown for the tab node. If null or empty, this will use the language line "{CraftTreeName}_{<paramref name="tabId"/>}" instead.</param>
         /// <param name="tabSprite">The sprite used for the tab node.</param>
+        /// <param name="language">The language for the display name. Defaults to English.</param>
         /// <param name="parentTabId">Optional. The parent tab of this tab.<para/>
         /// When this value is null, the tab will be added to the root of the craft tree.</param>
-        public ModCraftTreeRoot AddTabNode(string tabId, string displayText, UnityEngine.Sprite tabSprite, string parentTabId = null)
+        public ModCraftTreeRoot AddTabNode(string tabId, string displayText, UnityEngine.Sprite tabSprite, string language = "English", string parentTabId = null)
         {
             if(string.IsNullOrWhiteSpace(tabId))
                 throw new ArgumentNullException($"{this.SchemeAsString} tried to add a tab without an id! tabid cannot be null or empty spaces!");
@@ -123,7 +125,7 @@
 
             if(!parentTab.ChildNodes.Any(node => node.Action == TreeAction.Craft))
             {
-                ModCraftTreeTab tab = parentTab.AddTabNode(tabId, displayText, tabSprite);
+                ModCraftTreeTab tab = parentTab.AddTabNode(tabId, displayText, tabSprite, language);
                 CraftTreeLinkingNodes[tabId] = tab;
             }
             else

--- a/SMLHelper/Crafting/ModCraftTreeTab.cs
+++ b/SMLHelper/Crafting/ModCraftTreeTab.cs
@@ -1,4 +1,7 @@
-﻿namespace SMLHelper.Crafting
+﻿using SMLHelper.Handlers;
+using SMLHelper.Utility;
+
+namespace SMLHelper.Crafting
 {
     using Assets;
     using Patchers;
@@ -10,65 +13,72 @@
     /// <seealso cref="ModCraftTreeLinkingNode" />
     public class ModCraftTreeTab : ModCraftTreeLinkingNode
     {
-        private readonly string DisplayText;
+        private readonly string _displayText;
+        private readonly string _language;
 #if SUBNAUTICA
-        private readonly Atlas.Sprite Asprite;
+        private readonly Atlas.Sprite _aSprite;
 #endif
-        private readonly Sprite Usprite;
-        private readonly bool IsExistingTab;
-        private readonly string ModName;
+        private readonly Sprite _uSprite;
+        private readonly bool _isExistingTab;
 
 #if SUBNAUTICA
-        internal ModCraftTreeTab(string modName, string nameID, string displayText, Atlas.Sprite sprite)
+        internal ModCraftTreeTab(string nameID, string displayText, string language, Atlas.Sprite sprite)
             : base(nameID, TreeAction.Expand, TechType.None)
         {
-            DisplayText = displayText;
-            Asprite = sprite;
-            Usprite = null;
-            ModName = modName;
+            _displayText = displayText;
+            _aSprite = sprite;
+            _uSprite = null;
+            _language = language;
         }
 #endif
 
-        internal ModCraftTreeTab(string modName, string nameID, string displayText, Sprite sprite)
+        internal ModCraftTreeTab(string nameID, string displayText, string language, Sprite sprite)
             : base(nameID, TreeAction.Expand, TechType.None)
         {
-            DisplayText = displayText;
+            _displayText = displayText;
+            _language = language;
 #if SUBNAUTICA
-            Asprite = null;
+            _aSprite = null;
 #endif
-            Usprite = sprite;
-            ModName = modName;
+            _uSprite = sprite;
         }
 
-        internal ModCraftTreeTab(string modName, string nameID)
+        internal ModCraftTreeTab(string nameID)
             : base(nameID, TreeAction.Expand, TechType.None)
         {
-            IsExistingTab = true;
-            ModName = modName;
+            _isExistingTab = true;
         }
 
         internal override void LinkToParent(ModCraftTreeLinkingNode parent)
         {
             base.LinkToParent(parent);
 
-            if (IsExistingTab)
+            if (_isExistingTab)
             {
                 return;
             }
 
-            LanguagePatcher.AddCustomLanguageLine(ModName, $"{base.SchemeAsString}Menu_{Name}", DisplayText);
+            var langKey = $"{base.SchemeAsString}Menu_{Name}";
+            if (!string.IsNullOrEmpty(_displayText))
+            {
+                LanguageHandler.SetLanguageLine(langKey, _displayText, _language);
+            }
+            else if (string.IsNullOrEmpty(Language.main.Get(langKey)))
+            {
+                InternalLogger.Warn($"Display name was not specified and no existing language line has been found for CraftTree tab '{Name}'.");
+            }
 
             string spriteID = $"{SchemeAsString}_{Name}";
 
 #if SUBNAUTICA
             ModSprite modSprite;
-            if (Asprite != null)
+            if (_aSprite != null)
             {
-                modSprite = new ModSprite(SpriteManager.Group.Category, spriteID, Asprite);
+                modSprite = new ModSprite(SpriteManager.Group.Category, spriteID, _aSprite);
             }
             else
             {
-                modSprite = new ModSprite(SpriteManager.Group.Category, spriteID, Usprite);
+                modSprite = new ModSprite(SpriteManager.Group.Category, spriteID, _uSprite);
 
             }
 

--- a/SMLHelper/Handlers/Enums/Extensions/EnumExtensions_TechCategory.cs
+++ b/SMLHelper/Handlers/Enums/Extensions/EnumExtensions_TechCategory.cs
@@ -11,16 +11,30 @@ public static partial class EnumExtensions
     /// Adds a display name to this instance.
     /// </summary>
     /// <param name="builder">The current enum object instance.</param>
-    /// <param name="displayName">The display name of the Tech Category. Can be anything.</param>
+    /// <param name="displayName">The display name of the Tech Category, can be anything. If null or empty, this will use the language line "TechCategory{enumName}" instead.</param>
+    /// <param name="language">The language for the display name. Defaults to English.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
-    public static EnumBuilder<TechCategory> WithPdaInfo(this EnumBuilder<TechCategory> builder, string displayName)
+    public static EnumBuilder<TechCategory> WithPdaInfo(this EnumBuilder<TechCategory> builder, string displayName, string language = "English")
     {
         var category = (TechCategory)builder;
         var name = category.ToString();
         
-        uGUI_BlueprintsTab.techCategoryStrings.valueToString[category] = "TechCategory" + displayName;
-        LanguageHandler.SetLanguageLine("TechCategory" + name, displayName);
+        if (!string.IsNullOrEmpty(displayName))
+        {
+            LanguageHandler.SetLanguageLine("TechCategory" + name, displayName, language);
+            uGUI_BlueprintsTab.techCategoryStrings.valueToString[category] = "TechCategory" + displayName;
+            return builder;
+        }
 
+        var friendlyName = Language.main.Get("TechCategory" + name);
+        if (string.IsNullOrEmpty(friendlyName))
+        {
+            InternalLogger.Warn($"Display name for TechCategory '{name}' is not specified and no language key has been found. Setting display name to 'TechCategory{name}'.");
+            uGUI_BlueprintsTab.techCategoryStrings.valueToString[category] = "TechCategory" + name;
+            return builder;
+        }
+        
+        uGUI_BlueprintsTab.techCategoryStrings.valueToString[category] = "TechCategory" + friendlyName;
         return builder;
     }
 

--- a/SMLHelper/Handlers/Enums/Extensions/EnumExtensions_TechGroup.cs
+++ b/SMLHelper/Handlers/Enums/Extensions/EnumExtensions_TechGroup.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using SMLHelper.Utility;
 
 // ReSharper disable once CheckNamespace
 namespace SMLHelper.Handlers;
@@ -9,13 +10,22 @@ public static partial class EnumExtensions
     /// Adds a display name to this instance.
     /// </summary>
     /// <param name="builder">The current custom enum object instance.</param>
-    /// <param name="displayName">The display name of the Tech Group. Can be anything.</param>
+    /// <param name="displayName">The display name of the Tech Group, can be anything. If null or empty, this will use the language line "Group{enumName}" instead.</param>
+    /// <param name="language">The language for the display name. Defaults to English.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
-    public static EnumBuilder<TechGroup> WithPdaInfo(this EnumBuilder<TechGroup> builder, string displayName)
+    public static EnumBuilder<TechGroup> WithPdaInfo(this EnumBuilder<TechGroup> builder, string displayName, string language = "English")
     {
         var techGroup = (TechGroup)builder;
         var name = builder.ToString();
-        LanguageHandler.SetLanguageLine("Group" + name, displayName);
+        
+        if (!string.IsNullOrEmpty(displayName))
+        {
+            LanguageHandler.SetLanguageLine("Group" + name, displayName, language);
+        }
+        else if (string.IsNullOrEmpty(Language.main.Get("Group" + name)))
+        {
+            InternalLogger.Warn($"Display name was not specified and no existing language line has been found for TechGroup '{name}'.");
+        }
         
         if (!uGUI_BlueprintsTab.groups.Contains(techGroup))
             uGUI_BlueprintsTab.groups.Add(techGroup);

--- a/SMLHelper/Handlers/ItemActionHandler.cs
+++ b/SMLHelper/Handlers/ItemActionHandler.cs
@@ -1,4 +1,6 @@
-﻿namespace SMLHelper.Handlers
+﻿using SMLHelper.Utility;
+
+namespace SMLHelper.Handlers
 {
     using SMLHelper.Patchers;
     using System;
@@ -13,12 +15,20 @@
         /// </summary>
         /// <param name="targetTechType">The <see cref="TechType"/> to which the left click action will be assigned</param>
         /// <param name="callback">The method which will be called when a matching <see cref="InventoryItem"/> with the specified <see cref="TechType"/> was left-clicked</param>
-        /// <param name="tooltip">The secondary tooltip which will appear in the description of the item</param>
-        /// <param name="condition">The condition which must return <see langword="true"/> for the action to be called when the item is clicked<para/>If ommited, the action will always be called</param>
-        public static void RegisterLeftClickAction(TechType targetTechType, Action<InventoryItem> callback, string tooltip, Predicate<InventoryItem> condition)
+        /// <param name="tooltip">The secondary tooltip which will appear in the description of the item. If null or empty, this will use the language line "LeftClickAction_{<paramref name="targetTechType"/>}" instead.</param>
+        /// <param name="language">The language for the tooltip. Defaults to English.</param>
+        /// <param name="condition">The condition which must return <see langword="true"/> for the action to be called when the item is clicked<para/>If omitted, the action will always be called</param>
+        public static void RegisterLeftClickAction(TechType targetTechType, Action<InventoryItem> callback, string tooltip, string language = null, Predicate<InventoryItem> condition = null)
         {
             string languageLine = $"LeftClickAction_{targetTechType.AsString()}";
-            LanguageHandler.SetLanguageLine(languageLine, tooltip);
+            if (!string.IsNullOrEmpty(tooltip))
+            {
+                LanguageHandler.SetLanguageLine(languageLine, tooltip, language);
+            }
+            else if (string.IsNullOrEmpty(Language.main.Get(languageLine)))
+            {
+                InternalLogger.Warn($"Tooltip was not specified and no existing language line has been found for LeftClickAction '{targetTechType}'.");
+            }
 
             condition = condition ?? ((item) => true);
             ItemActionPatcher.LeftClickActions.Add(targetTechType, new ItemActionPatcher.CustomItemAction(callback, languageLine, condition));
@@ -30,11 +40,12 @@
         /// <param name="targetTechType">The <see cref="TechType"/> which the middle click action will be assigned</param>
         /// <param name="callback">The method which will be called when a matching <see cref="InventoryItem"/> with the specified <see cref="TechType"/> was middle-clicked</param>
         /// <param name="tooltip">The secondary tooltip which will appear in the description of the item</param>
-        /// <param name="condition">The condition which must return <see langword="true"/> for the action to be called when the item is clicked<para/>If ommited, the action will always be called</param>
-        public static void RegisterMiddleClickAction(TechType targetTechType, Action<InventoryItem> callback, string tooltip, Predicate<InventoryItem> condition)
+        /// <param name="language">The language for the tooltip. Defaults to English.</param>
+        /// <param name="condition">The condition which must return <see langword="true"/> for the action to be called when the item is clicked<para/>If omitted, the action will always be called</param>
+        public static void RegisterMiddleClickAction(TechType targetTechType, Action<InventoryItem> callback, string tooltip, string language = null, Predicate<InventoryItem> condition = null)
         {
             string languageLine = $"MiddleClickAction_{targetTechType.AsString()}";
-            LanguageHandler.SetLanguageLine(languageLine, tooltip);
+            LanguageHandler.SetLanguageLine(languageLine, tooltip, language);
 
             condition = condition ?? ((item) => true);
             ItemActionPatcher.MiddleClickActions.Add(targetTechType, new ItemActionPatcher.CustomItemAction(callback, languageLine, condition));

--- a/SMLHelper/Handlers/LanguageHandler.cs
+++ b/SMLHelper/Handlers/LanguageHandler.cs
@@ -20,7 +20,7 @@ namespace SMLHelper.Handlers
         /// <param name="lineId">The ID of the entry, this is what is used to get the actual text.</param>
         /// <param name="text">The actual text related to the entry.</param>
         /// <param name="language">The language for this specific entry. Defaults to English.</param>
-        public static void SetLanguageLine(string lineId, string text, string language)
+        public static void SetLanguageLine(string lineId, string text, string language = "English")
         {
             LanguagePatcher.AddCustomLanguageLine(lineId, text, language);
         }
@@ -57,7 +57,7 @@ namespace SMLHelper.Handlers
         /// Registers language entries for a specific language.
         /// </summary>
         /// <param name="language">The language to register the entries to.</param>
-        /// <param name="languageStrings">The language entries to register. K</param>
+        /// <param name="languageStrings">The language entries to register.</param>
         public static void RegisterLocalization(string language, Dictionary<string, string> languageStrings)
         {
             if (string.IsNullOrEmpty(language) || languageStrings is null || languageStrings.Count <= 0)
@@ -75,7 +75,7 @@ namespace SMLHelper.Handlers
         /// <param name="techType">The <see cref="TechType"/> whose display name that is to be changed.</param>
         /// <param name="text">The new display name for the chosen <see cref="TechType"/>.</param>
         /// <param name="language">The language for this entry. Defaults to English.</param>
-        public static void SetTechTypeName(TechType techType, string text, string language)
+        public static void SetTechTypeName(TechType techType, string text, string language = "English")
         {
             LanguagePatcher.AddCustomLanguageLine(techType.AsString(), text, language);
         }
@@ -86,7 +86,7 @@ namespace SMLHelper.Handlers
         /// <param name="techType">The <see cref="TechType"/> whose tooltip that is to be changed.</param>
         /// <param name="text">The new tooltip for the chosen <see cref="TechType"/>.</param>
         /// <param name="language">The language for this entry. Defaults to English.</param>
-        public static void SetTechTypeTooltip(TechType techType, string text, string language)
+        public static void SetTechTypeTooltip(TechType techType, string text, string language = "English")
         {
             LanguagePatcher.AddCustomLanguageLine($"Tooltip_{techType.AsString()}", text, language);
         }

--- a/SMLHelper/Handlers/LanguageHandler.cs
+++ b/SMLHelper/Handlers/LanguageHandler.cs
@@ -1,4 +1,10 @@
-﻿namespace SMLHelper.Handlers
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using UnityEngine;
+
+namespace SMLHelper.Handlers
 {
     using Patchers;
     using Utility;
@@ -13,11 +19,54 @@
         /// </summary>
         /// <param name="lineId">The ID of the entry, this is what is used to get the actual text.</param>
         /// <param name="text">The actual text related to the entry.</param>
-        public static void SetLanguageLine(string lineId, string text)
+        /// <param name="language">The language for this specific entry. Defaults to English.</param>
+        public static void SetLanguageLine(string lineId, string text, string language)
         {
-            string modName = ReflectionHelper.CallingAssemblyNameByStackTrace();
+            LanguagePatcher.AddCustomLanguageLine(lineId, text, language);
+        }
 
-            LanguagePatcher.AddCustomLanguageLine(modName, lineId, text);
+        /// <summary>
+        /// <para>Registers a folder path as a Multi-Language json files folder.</para>
+        /// Please make sure that the passed folder contains json files that are properly named after the language each json file localizes.
+        /// </summary>
+        /// <param name="languageFolderName">the folder name. This folder is expected to be found at ModFolder/<paramref name="languageFolderName"/>.</param>
+        public static void RegisterLocalizationFolder(string languageFolderName = "Localization")
+        {
+            var callingAssembly = Assembly.GetCallingAssembly();
+            callingAssembly = callingAssembly == Assembly.GetExecutingAssembly()
+                ? ReflectionHelper.CallingAssemblyByStackTrace()
+                : callingAssembly;
+            
+            var path = Path.Combine(Path.GetDirectoryName(callingAssembly.Location)!, languageFolderName);
+            if (!Directory.Exists(path))
+            {
+                InternalLogger.Error($"Directory '{path}' does not exist. Skipping localization registration.");
+                return;
+            }
+            
+            LanguagePatcher.LanguagePaths.Add(path);
+
+            var lang = Path.GetFileNameWithoutExtension(PlayerPrefs.GetString("Language"));
+            if (!string.IsNullOrEmpty(lang))
+            {
+                LanguagePatcher.LoadLanguageImpl(lang, path);
+            }
+        }
+
+        /// <summary>
+        /// Registers language entries for a specific language.
+        /// </summary>
+        /// <param name="language">The language to register the entries to.</param>
+        /// <param name="languageStrings">The language entries to register. K</param>
+        public static void RegisterLocalization(string language, Dictionary<string, string> languageStrings)
+        {
+            if (string.IsNullOrEmpty(language) || languageStrings is null || languageStrings.Count <= 0)
+            {
+                InternalLogger.Error($"Localization registration failed. Language name or values are empty or null. Stacktrace: {Environment.StackTrace}");
+                return;
+            }
+            
+            LanguagePatcher.AddCustomLanguageLines(language, languageStrings);
         }
 
         /// <summary>
@@ -25,11 +74,10 @@
         /// </summary>
         /// <param name="techType">The <see cref="TechType"/> whose display name that is to be changed.</param>
         /// <param name="text">The new display name for the chosen <see cref="TechType"/>.</param>
-        public static void SetTechTypeName(TechType techType, string text)
+        /// <param name="language">The language for this entry. Defaults to English.</param>
+        public static void SetTechTypeName(TechType techType, string text, string language)
         {
-            string modName = ReflectionHelper.CallingAssemblyNameByStackTrace();
-
-            LanguagePatcher.AddCustomLanguageLine(modName, techType.AsString(), text);
+            LanguagePatcher.AddCustomLanguageLine(techType.AsString(), text, language);
         }
 
         /// <summary>
@@ -37,11 +85,10 @@
         /// </summary>
         /// <param name="techType">The <see cref="TechType"/> whose tooltip that is to be changed.</param>
         /// <param name="text">The new tooltip for the chosen <see cref="TechType"/>.</param>
-        public static void SetTechTypeTooltip(TechType techType, string text)
+        /// <param name="language">The language for this entry. Defaults to English.</param>
+        public static void SetTechTypeTooltip(TechType techType, string text, string language)
         {
-            string modName = ReflectionHelper.CallingAssemblyNameByStackTrace();
-
-            LanguagePatcher.AddCustomLanguageLine(modName, $"Tooltip_{techType.AsString()}", text);
+            LanguagePatcher.AddCustomLanguageLine($"Tooltip_{techType.AsString()}", text, language);
         }
     }
 }

--- a/SMLHelper/Handlers/LanguageHandler.cs
+++ b/SMLHelper/Handlers/LanguageHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using Newtonsoft.Json;
 using UnityEngine;
 
 namespace SMLHelper.Handlers
@@ -43,13 +44,18 @@ namespace SMLHelper.Handlers
                 InternalLogger.Error($"Directory '{path}' does not exist. Skipping localization registration.");
                 return;
             }
-            
-            LanguagePatcher.LanguagePaths.Add(path);
 
-            var lang = Path.GetFileNameWithoutExtension(PlayerPrefs.GetString("Language"));
-            if (!string.IsNullOrEmpty(lang))
+            foreach (var file in Directory.GetFiles(path))
             {
-                LanguagePatcher.LoadLanguageImpl(lang, path);
+                var content = JsonConvert.DeserializeObject<Dictionary<string, string>>(File.ReadAllText(file));
+                if (content is null)
+                {
+                    InternalLogger.Warn($"Localization file '{file}' is empty, skipping registration.");
+                    continue;
+                }
+                
+                var languageName = Path.GetFileNameWithoutExtension(file);
+                RegisterLocalization(languageName, content);
             }
         }
 

--- a/SMLHelper/Options/Attributes/ModOptionAttribute.cs
+++ b/SMLHelper/Options/Attributes/ModOptionAttribute.cs
@@ -41,7 +41,7 @@
         /// An optional id to be parsed with <see cref="Language.Get(string)"/> for the label, allowing for custom language-based strings
         /// via the <see cref="LanguageHandler"/> API. If this is set, it will take precedence.
         /// </summary>
-        /// <seealso cref="LanguageHandler.SetLanguageLine(string, string)"/>
+        /// <seealso cref="LanguageHandler.SetLanguageLine(string, string, string)"/>
         /// <seealso cref="Language.Get(string)"/>
         public string LabelLanguageId { get; set; }
 

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -1,28 +1,44 @@
-﻿namespace SMLHelper.Patchers
+﻿using System.Linq;
+
+namespace SMLHelper.Patchers
 {
-    using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Reflection;
-    using System.Text;
     using BepInEx.Logging;
     using HarmonyLib;
-    using SMLHelper.Utility;
+    using Newtonsoft.Json;
+    using Handlers;
+    using UnityEngine;
+    using Utility;
 
-    internal class LanguagePatcher
+    internal static class LanguagePatcher
     {
-        private static readonly string LanguageDir = Path.Combine(Path.Combine(BepInEx.Paths.ConfigPath, Assembly.GetExecutingAssembly().GetName().Name), "Language");
-        private static readonly string LanguageOrigDir = Path.Combine(LanguageDir, "Originals");
-        private static readonly string LanguageOverDir = Path.Combine(LanguageDir, "Overrides");
-        private const char KeyValueSeparator = ':';
-        private const int SplitCount = 2;
+        private const string FallbackLanguage = "English";
 
-        private static readonly Dictionary<string, Dictionary<string, string>> originalCustomLines = new();
-        private static readonly Dictionary<string, string> customLines = new();
+        internal static readonly List<string> LanguagePaths = new();
+        private static readonly Dictionary<string, string> _currentLanguageStrings = new();
+        private static readonly Dictionary<string, string> _fallbackLanguageStrings = new();
+        private static readonly Dictionary<string, Dictionary<string, string>> _customLines = new();
+        private static string _currentLanguage = "English";
+
+        static LanguagePatcher()
+        {
+            string savedLanguagePath = PlayerPrefs.GetString("Language", null); // tries to find the last loaded language, sets the new variable to null if the last loaded language cannot be found
+            if (!string.IsNullOrEmpty(savedLanguagePath))
+            {
+                _currentLanguage = Path.GetFileNameWithoutExtension(savedLanguagePath);
+            }
+        }
 
         internal static void RepatchCheck(ref Language __instance, string key)
         {
-            if (string.IsNullOrEmpty(key) || !customLines.TryGetValue(key, out string customValue))
+            if (string.IsNullOrEmpty(key))
+            {
+                return;
+            }
+
+            if ((!_customLines.TryGetValue(_currentLanguage, out var customStrings) || !customStrings.TryGetValue(key, out var customValue)) && 
+                (!_customLines.TryGetValue(FallbackLanguage, out customStrings) || !customStrings.TryGetValue(key, out customValue)))
             {
                 return;
             }
@@ -35,249 +51,120 @@
 
         internal static void InsertCustomLines(ref Language __instance)
         {
-            // Direct access to private fields made possible by https://github.com/CabbageCrow/AssemblyPublicizer/
-            // See README.md for details.
-            Dictionary<string, string> strings = __instance.strings;
-            foreach (KeyValuePair<string, string> a in customLines)
+            var fallbackStrings = _customLines[FallbackLanguage];
+            var currentStrings = _customLines[_currentLanguage];
+
+            foreach (var fallbackString in fallbackStrings)
             {
-                strings[a.Key] = a.Value;
+                // Allow mixed-in English if the current language doesn't have a translation for a key. 
+                if (currentStrings.TryGetValue(fallbackString.Key, out var currentValue))
+                    __instance.strings[fallbackString.Key] = currentValue;
+                else
+                    __instance.strings[fallbackString.Key] = fallbackString.Value;
+            }
+            
+            if (_currentLanguage == FallbackLanguage)
+                return;
+            
+            var diffStrings = currentStrings.Except(fallbackStrings);
+		
+            // Just in case there are current language strings that aren't in the fallback language, we implement them as well.
+            foreach (var currentOnlyString in diffStrings)
+            {
+                __instance.strings[currentOnlyString.Key] = currentOnlyString.Value;
+            }
+        }
+        
+        private static void LoadLanguageFilePrefix(string language)
+        {
+            _currentLanguage = Path.GetFileNameWithoutExtension(language);
+            LoadLanguages(language);
+        }
+
+        internal static void LoadLanguages(string language = FallbackLanguage)
+        {
+            foreach (var languagePath in LanguagePaths)
+            {
+                LoadLanguageImpl(language, languagePath);
+            }
+        }
+        
+        internal static void LoadLanguageImpl(string language, string languageFolder)
+        {
+            string fallbackPath = Path.Combine(languageFolder, $"{FallbackLanguage}.json");
+            var file = Path.Combine(languageFolder, language + ".json");
+            if (!File.Exists(file)) // if the preferred language doesn't have a file, use english, and return.
+            {
+                file = fallbackPath;
+                if (File.Exists(file))
+                {
+                    SetLanguages(file, false);
+                    return;
+                }
+            }
+            
+            SetLanguages(file, false); // load the preferred language
+            
+            if (language != FallbackLanguage) SetLanguages(fallbackPath, true); // if the current language is not already the fallback, then load the fallback language. some mixed in english is much better than raw language keys.
+
+            void SetLanguages(string fileToSet, bool loadIntoFallback)
+            {
+                var deserialize = JsonConvert.DeserializeObject<Dictionary<string, string>>(File.ReadAllText(fileToSet));
+                if (deserialize is null)
+                    return;
+
+                var dictionary = loadIntoFallback
+                    ? _fallbackLanguageStrings
+                    : _currentLanguageStrings;
+                
+                dictionary.Clear();
+
+                foreach (var kvp in deserialize)
+                {
+                    dictionary[kvp.Key] = kvp.Value;
+                    // If we are loading a fallback language, we should ONLY set a language line if a translation for the key doesn't already exist. Fallback should never override current language.
+                    if (!loadIntoFallback || _currentLanguageStrings.ContainsKey(kvp.Key))
+                    {
+                        LanguageHandler.SetLanguageLine(kvp.Key, kvp.Value, _currentLanguage);
+                    }
+                }
             }
         }
 
         internal static void Patch(Harmony harmony)
         {
-            if (!Directory.Exists(LanguageDir))
-            {
-                Directory.CreateDirectory(LanguageDir);
-            }
-
-            WriteOriginalCustomLines();
-
-            ReadOverrideCustomLines();
-
-
-            HarmonyMethod repatchCheckMethod = new(AccessTools.Method(typeof(LanguagePatcher), nameof(LanguagePatcher.RepatchCheck)));
-            HarmonyMethod insertLinesMethod = new(AccessTools.Method(typeof(LanguagePatcher), nameof(LanguagePatcher.InsertCustomLines)));
+            HarmonyMethod repatchCheckMethod = new(AccessTools.Method(typeof(LanguagePatcher), nameof(RepatchCheck)));
+            HarmonyMethod insertLinesMethod = new(AccessTools.Method(typeof(LanguagePatcher), nameof(InsertCustomLines)));
+            HarmonyMethod loadLanguagesMethod = new(AccessTools.Method(typeof(LanguagePatcher), nameof(LoadLanguageFilePrefix)));
 
             harmony.Patch(AccessTools.Method(typeof(Language), nameof(Language.ParseMetaData)), prefix: insertLinesMethod);
             harmony.Patch(AccessTools.Method(typeof(Language), nameof(Language.GetKeysFor)), prefix: insertLinesMethod);
             harmony.Patch(AccessTools.Method(typeof(Language), nameof(Language.TryGet)), prefix: repatchCheckMethod);
             harmony.Patch(AccessTools.Method(typeof(Language), nameof(Language.Contains)), prefix: repatchCheckMethod);
+            harmony.Patch(AccessTools.Method(typeof(Language), nameof(Language.LoadLanguageFile)), prefix: loadLanguagesMethod);
 
             InternalLogger.Log("LanguagePatcher is done.", LogLevel.Debug);
         }
 
-        private static void WriteOriginalCustomLines()
+        internal static void AddCustomLanguageLine(string lineId, string text, string language)
         {
-            if (!Directory.Exists(LanguageOrigDir))
-            {
-                Directory.CreateDirectory(LanguageOrigDir);
-            }
+            if (!_customLines.ContainsKey(language))
+                _customLines[language] = new();
 
-            if (originalCustomLines.Count == 0)
-            {
-                return;
-            }
-
-            int filesWritten = 0;
-            foreach (string modKey in originalCustomLines.Keys)
-            {
-                if (!FileNeedsRewrite(modKey))
-                {
-                    continue; // File is identical to captured lines. No need to rewrite it.
-                }
-
-                InternalLogger.Log($"Writing original language lines file for {modKey}", LogLevel.Debug);
-                if (WriteOriginalLinesFile(modKey))
-                {
-                    filesWritten++;
-                }
-                else
-                {
-                    InternalLogger.Log($"Error writing language lines file for {modKey}", LogLevel.Warning);
-                }
-            }
-
-            if (filesWritten > 0)
-            {
-                InternalLogger.Log($"Updated {filesWritten} of {originalCustomLines.Count} original language files.", LogLevel.Debug);
-            }
+            _customLines[language][lineId] = text;
         }
 
-        private static bool WriteOriginalLinesFile(string modKey)
+        internal static void AddCustomLanguageLines(string language, Dictionary<string, string> languageStrings)
         {
-            if (string.IsNullOrEmpty(modKey))
+            if (!_customLines.ContainsKey(language))
+                _customLines[language] = new();
+
+            var customStrings = _customLines[language];
+            
+            foreach (var languageString in languageStrings)
             {
-                return false;
+                customStrings[languageString.Key] = languageString.Value;
             }
-
-            Dictionary<string, string> modCustomLines = originalCustomLines[modKey];
-            StringBuilder text = new();
-            foreach (string langLineKey in modCustomLines.Keys)
-            {
-                if (!modCustomLines.TryGetValue(langLineKey, out string line) || string.IsNullOrEmpty(line))
-                {
-                    continue;
-                }
-
-                string valueToWrite = line.Replace("\n", "\\n").Replace("\r", "\\r");
-                text.AppendLine($"{langLineKey}{KeyValueSeparator}{valueToWrite}");
-            }
-
-            if (text.Length > 0)
-            {
-                File.WriteAllText(Path.Combine(LanguageOrigDir, $"{modKey}.txt"), text.ToString(), Encoding.UTF8);
-                return true;
-            }
-
-            return false;            
-        }
-
-        private static void ReadOverrideCustomLines()
-        {
-            if (!Directory.Exists(LanguageOverDir))
-            {
-                Directory.CreateDirectory(LanguageOverDir);
-            }
-
-            string[] files = Directory.GetFiles(LanguageOverDir);
-
-            InternalLogger.Log($"{files.Length} language override files found.", LogLevel.Debug);
-
-            if (files.Length == 0)
-            {
-                return;
-            }
-
-            foreach (string file in files)
-            {
-                string modName = Path.GetFileNameWithoutExtension(file);
-
-                if (!originalCustomLines.ContainsKey(modName))
-                {
-                    continue; // Not for a mod we know about
-                }
-
-                string[] languageLines = File.ReadAllLines(file, Encoding.UTF8);
-
-                Dictionary<string, string> originalLines = originalCustomLines[modName];
-
-                int overridesApplied = ExtractOverrideLines(modName, languageLines, originalLines);
-
-                InternalLogger.Log($"Applied {overridesApplied} language overrides to mod {modName}.", LogLevel.Info);
-            }
-        }
-
-        internal static int ExtractOverrideLines(string modName, string[] languageLines, Dictionary<string, string> originalLines)
-        {
-            int overridesApplied = 0;
-            for (int lineIndex = 0; lineIndex < languageLines.Length; lineIndex++)
-            {
-                string line = languageLines[lineIndex];
-                if (string.IsNullOrEmpty(line))
-                {
-                    continue; // Skip empty lines
-                }
-
-                string[] split = line.Split(new[] { KeyValueSeparator }, SplitCount, StringSplitOptions.RemoveEmptyEntries);
-
-                string key = split[0];
-
-                if (split.Length != SplitCount)
-                {
-                    InternalLogger.Log($"Line '{lineIndex}' in language override file for '{modName}' was incorrectly formatted.", LogLevel.Warning);
-                    continue; // Not correctly formatted
-                }
-
-                if (!originalLines.ContainsKey(key))
-                {
-                    InternalLogger.Log($"Key '{key}' on line '{lineIndex}' in language override file for '{modName}' did not match an original key.", LogLevel.Warning);
-                    continue; // Skip keys we don't recognize.
-                }
-
-                string value = RemoveOptionalDelimiters(split[1]);
-
-                customLines[key] = value.Replace("\\n", "\n").Replace("\\r", "\r");
-                overridesApplied++;
-            }
-
-            return overridesApplied;
-        }
-
-        private static string RemoveOptionalDelimiters(string value)
-        {
-            const int firstChar = 0;
-            int lastChar = value.Length - 1;
-
-            if (value[firstChar] == '{' && value[lastChar] == '}' &&
-                value[firstChar + 2] != '}' && value[lastChar - 2] != '{')
-            {
-                value = value.Substring(1, lastChar - 1);
-            }
-
-            return value;
-        }
-
-        private static bool FileNeedsRewrite(string modKey)
-        {
-            Dictionary<string, string> modCustomLines = originalCustomLines[modKey];
-            string fileName = Path.Combine(LanguageOrigDir, $"{modKey}.txt");
-
-            if (!File.Exists(fileName))
-            {
-                return true; // File not found
-            }
-
-            string[] lines = File.ReadAllLines(fileName, Encoding.UTF8);
-
-            if (lines.Length != modCustomLines.Count)
-            {
-                return true; // Difference in line count
-            }
-
-            // Confirm if the file actually needs to be updated
-            foreach (string line in lines)
-            {
-                string[] split = line.Split(new[] { KeyValueSeparator }, SplitCount, StringSplitOptions.RemoveEmptyEntries);
-
-                if (split.Length != SplitCount)
-                {
-                    return true; // Not correctly formatted
-                }
-
-                string lineKey = split[0];
-                string lineValue = split[1].Replace("\\n", "\n").Replace("\\r", "\r");
-
-                if (modCustomLines.TryGetValue(lineKey, out string origValue))
-                {
-                    if (origValue != lineValue)
-                    {
-                        return true; // Difference in line content
-                    }
-                }
-                else
-                {
-                    return true; // Key not found
-                }
-            }
-
-            return false; // All lines matched and valid
-        }
-
-        internal static void AddCustomLanguageLine(string modAssemblyName, string lineId, string text)
-        {
-            if (!originalCustomLines.ContainsKey(modAssemblyName))
-            {
-                originalCustomLines.Add(modAssemblyName, new Dictionary<string, string>());
-            }
-
-            originalCustomLines[modAssemblyName][lineId] = text;
-            customLines[lineId] = text;
-        }
-
-        internal static string GetCustomLine(string key)
-        {
-            return customLines[key];
         }
     }
 }

--- a/SMLHelper/Patchers/TooltipPatcher.cs
+++ b/SMLHelper/Patchers/TooltipPatcher.cs
@@ -139,8 +139,11 @@
             }
 
             Initialized = true;
+            
+            var smlFolder = Path.Combine(BepInEx.Paths.ConfigPath, Assembly.GetExecutingAssembly().GetName().Name);
+            Directory.CreateDirectory(smlFolder);
 
-            string configPath = Path.Combine(Path.Combine(BepInEx.Paths.ConfigPath, Assembly.GetExecutingAssembly().GetName().Name), "ExtraItemInfo.txt");
+            var configPath = Path.Combine(smlFolder, "ExtraItemInfo.txt");
 
             if (!File.Exists(configPath))
             {
@@ -150,7 +153,7 @@
                 return;
             }
 
-            string fileContents = File.ReadAllText(configPath);
+            var fileContents = File.ReadAllText(configPath);
 
             switch (fileContents)
             {


### PR DESCRIPTION
### Changes made in this pull request

  - Added Localization support
  - Removed the old Originals and Overrides systems

Now modders can implement localizations in two different ways:

## Localization Folder (json files)
With this approach, you can have json files with that contain language entries, then the json file must be named exactly the same as the language it tries to translate. I.E: If the file containing translations for English, it must be named `English.json`.  
Then you put these json files in a folder typically named `Localization` under your mod's folder.  

In this approach, registering the localization is one line of code:
```csharp
// by default, the languageFolderName is set to "Localization"
LanguageHandler.RegisterLocalizationFolder(languageFolderName: "Localization");
```

## Dictionaries
With this approach, you can feed SML a dictionary of language entries, then register them to the language they translate.  
```csharp
Dictionary<string, string> languageEntriesEng = new()
{
   { "TitaniumClone", "Titanium Clone" }, { "Tooltip_TitaniumClone", "Titanium clone that makes me go yes." }
};

LanguageHandler.RegisterLocalization("English", languageEntriesEng);
```
Full example can be found in the [LocalizationExample](https://github.com/SubnauticaModding/SMLHelper/blob/73ee7e02dfb795f7db4da630030b9a5a2be43158/Example%20mod/LocalizationExample.cs) file.